### PR TITLE
Hotfix/test ready 1차 테스트 반영사항 업데이트

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+out

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,6 @@ FROM nginx
 
 COPY --from=build /usr/app/out /usr/share/nginx/html
 
+COPY nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
+
 CMD	["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:current-slim
+FROM node:current-slim as build
 
 WORKDIR /usr/app/
 
@@ -14,4 +14,10 @@ COPY . .
 
 RUN pnpm build
 
-# CMD ["npm", "serve"]
+#-------------------
+
+FROM nginx
+
+COPY --from=build /usr/app/out /usr/share/nginx/html
+
+CMD	["nginx", "-g", "daemon off;"]

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -8,6 +8,7 @@ import { Logo, MyAlert } from "@/domain/shared/components/layout";
 import { useEffect } from "react";
 import { AlertType } from "@/domain/noti/types";
 import { setAlert } from "@/domain/noti/slices/notiSlice";
+import Image from "next/image";
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
   useMocking();
@@ -42,6 +43,14 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
 const CustomProvider = ({ children }: { children: React.ReactNode }) => {
   return (
     <Provider store={store}>
+      <Image
+        width={500}
+        height={500}
+        src="/background.svg"
+        alt="background"
+        sizes="100vw"
+        className="absolute top-0 sm:opacity-20 w-full"
+      />
       <Layout>{children}</Layout>
     </Provider>
   );

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -91,9 +91,7 @@ const Page = () => {
           })
         }
       >
-        <p>
-          {signupStep == SIGNUP_STEP.POLICY ? "Register New Account" : "Next"}
-        </p>
+        <p>{signupStep == SIGNUP_STEP.POLICY ? "회원가입 완료" : "다음"}</p>
       </Button>
     </form>
   );

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -83,11 +83,11 @@ const Page = () => {
         onClick={() =>
           handleSwitchSignupStep({
             postSignup: postSignup,
+            dispatch: dispatch,
             verify: verify,
             password: password,
             reEnterPassword: reEnterPW,
             signupStep: signupStep,
-            dispatch: dispatch,
           })
         }
       >

--- a/app/(main)/diary/read/page.tsx
+++ b/app/(main)/diary/read/page.tsx
@@ -21,7 +21,7 @@ const DiaryReadPage: React.FC = () => {
     if (date) {
       dispatch<any>(fetchDiaryDetail(date));
     }
-  }, []);
+  }, [date]);
 
   return (
     <div className="w-full min-h-screen flex justify-center items-start">
@@ -40,7 +40,7 @@ const DiaryReadPage: React.FC = () => {
           </div>
         </div>
         <div className="w-full max-w-md">
-          <p className="text-md h-full p-2 rounded-none overflow-y-auto">
+          <p className="text-md h-full p-2 rounded-none overflow-y-auto whitespace-pre-wrap">
             {queriedDiary.content}
           </p>
         </div>

--- a/app/(main)/diary/read/page.tsx
+++ b/app/(main)/diary/read/page.tsx
@@ -36,7 +36,7 @@ const DiaryReadPage: React.FC = () => {
             onClick={() => setShowModal(true)}
             className="absolute bottom-2 left-2 text-sm font-semibold rounded-full pl-2 pr-2 bg-white opacity-75 border shadow-md"
           >
-            AI 코멘트
+            AI 리뷰
           </div>
         </div>
         <div className="w-full max-w-md">
@@ -45,7 +45,7 @@ const DiaryReadPage: React.FC = () => {
           </p>
         </div>
         <Modal show={showModal} onClose={() => setShowModal(false)}>
-          <Modal.Header>AI 코멘트</Modal.Header>
+          <Modal.Header className="font-gamja">토닥토닥 AI</Modal.Header>
           <Modal.Body>
             <div className="space-y-6">
               <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">

--- a/app/(main)/diary/write/page.tsx
+++ b/app/(main)/diary/write/page.tsx
@@ -131,7 +131,7 @@ const DiaryWritePage: React.FC = () => {
       </div>
 
       <Modal show={commentView} onClose={handleCloseModal}>
-        <Modal.Header>토닥토닥</Modal.Header>
+        <Modal.Header className="font-gamja">토닥토닥 AI 코멘트</Modal.Header>
         <Modal.Body>
           <div className="space-y-6">
             <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">

--- a/app/(main)/diary/write/page.tsx
+++ b/app/(main)/diary/write/page.tsx
@@ -12,14 +12,13 @@ import { CHARACTER_REQUIRED_ALERT } from "@/domain/shared/constants";
 import { setAlert } from "@/domain/noti/slices/notiSlice";
 import {
   clearAiCommet,
-  setCommentView,
+  setAiCommentView,
 } from "@/domain/diary/slices/diarySlice";
 import { RootState } from "@/redux";
 import path from "@/domain/shared/routes";
 import { MoodSelector } from "@/domain/diary/components/MoodSelector";
 import { DiaryTextArea } from "@/domain/diary/components/DiaryTextArea";
 import { AlertType } from "@/domain/noti/types";
-import { toKSTISOString } from "@/domain/shared/function";
 
 const DiaryWritePage: React.FC = () => {
   const [selectedMood, setSelectedMood] = useState<string | null>(null);
@@ -76,31 +75,25 @@ const DiaryWritePage: React.FC = () => {
   };
 
   const handleCloseModal = () => {
-    dispatch(setCommentView(false));
+    dispatch(setAiCommentView(false));
     dispatch(clearAiCommet());
+    router.push(path.DIARY);
+    dispatch(
+      setAlert({
+        title: "알림",
+        message: "일기가 저장되었습니다.",
+        color: "success",
+      })
+    );
   };
 
   useEffect(() => {
-    if (isDiarySaved) {
-      removeTextLocalStorage();
-      router.push(path.DIARY);
-      dispatch(
-        setAlert({
-          title: "알림",
-          message: "일기가 저장되었습니다.",
-          color: "success",
-          callback: (
-            <AlertButton
-              onClick={() =>
-                router.push(`${path.READ}?date=${toKSTISOString(date)}`)
-              }
-              text="작성된 일기 보러가기"
-            />
-          ),
-        })
-      );
+    if (!isDiarySaved) {
+      return;
     }
-  }, [isDiarySaved, removeTextLocalStorage, dispatch]);
+    dispatch(setAiCommentView(true));
+    removeTextLocalStorage();
+  }, [isDiarySaved]);
 
   return (
     <div className="flex flex-col h-relative justify-between p-4">
@@ -117,7 +110,7 @@ const DiaryWritePage: React.FC = () => {
             <div>
               <p className="text-xs text-gray-500 ml-2">임시저장</p>
               <p className="text-xs text-gray-500 ml-2">
-                {toKSTISOString(date).split("T")[1].split(".")[0]}
+                {date.toTimeString().slice(0, 8)}
               </p>
             </div>
           </div>

--- a/app/(main)/home/page.tsx
+++ b/app/(main)/home/page.tsx
@@ -33,7 +33,7 @@ const Page: React.FC = () => {
           dataLength={feedList.length}
           next={fetchMoreData}
           hasMore={hasMore}
-          loader={<h4>로딩 중...</h4>}
+          loader={<></>}
           endMessage={
             <p style={{ textAlign: "center" }}>
               <b>모든 피드를 불러왔습니다.</b>

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import store, { RootState } from "@/redux";
-import {
-  useEmptyTokenRedirect,
-  useMocking,
-  useReissueToken,
-} from "@/domain/shared/hooks";
+import { useEmptyTokenRedirect, useMocking } from "@/domain/shared/hooks";
 import React, { useEffect } from "react";
 import { Provider, useDispatch, useSelector } from "react-redux";
 import {
@@ -18,7 +14,7 @@ import { AlertType } from "@/domain/noti/types";
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
   useMocking();
-  useReissueToken();
+  // useReissueToken();
   useEmptyTokenRedirect();
   const dispatch = useDispatch();
 

--- a/app/(main)/layout.tsx
+++ b/app/(main)/layout.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import store, { RootState } from "@/redux";
-import { useEmptyTokenRedirect, useMocking } from "@/domain/shared/hooks";
+import {
+  useEmptyTokenRedirect,
+  useLoginChecker,
+  useMocking,
+} from "@/domain/shared/hooks";
 import React, { useEffect } from "react";
 import { Provider, useDispatch, useSelector } from "react-redux";
 import {
@@ -14,8 +18,8 @@ import { AlertType } from "@/domain/noti/types";
 
 const Layout = ({ children }: { children: React.ReactNode }) => {
   useMocking();
-  // useReissueToken();
   useEmptyTokenRedirect();
+  useLoginChecker();
   const dispatch = useDispatch();
 
   const loginError = useSelector((state: RootState) => state.login.error);

--- a/app/(main)/my/page.tsx
+++ b/app/(main)/my/page.tsx
@@ -99,7 +99,7 @@ const Page = () => {
                     />
                   </div>
                   <p className="w-full mt-1 flex text-xs text-gray-400">
-                    Posted on: {myFeed.createdDate}
+                    {myFeed.createdDate} 공유
                   </p>
                 </div>
               ))}
@@ -108,7 +108,7 @@ const Page = () => {
         </div>
       </div>
       <Modal show={openModal} onClose={() => setOpenModal(false)}>
-        <Modal.Header>토닥토닥</Modal.Header>
+        <Modal.Header className="font-gamja">토닥토닥</Modal.Header>
         <Button
           onClick={() =>
             router.push(`${path.READ}/?date=${selectedFeed.diaryCreatedDate}`)

--- a/app/(main)/my/page.tsx
+++ b/app/(main)/my/page.tsx
@@ -70,7 +70,7 @@ const Page = () => {
             dataLength={myFeedList.length}
             next={fetchMoreData}
             hasMore={hasMore}
-            loader={<h4>로딩중 ...</h4>}
+            loader={<></>}
             endMessage={
               <p style={{ textAlign: "center" }}>
                 <b>모든 게시물을 불러왔습니다.</b>

--- a/app/(main)/my/page.tsx
+++ b/app/(main)/my/page.tsx
@@ -38,11 +38,13 @@ const Page = () => {
     dispatch<any>(fetchMyFeedEntries(myFeedAfter));
   };
 
-  const nickname = useSelector((state: RootState) => state.member.nickname);
-  const characterImageUrl = useSelector(
-    (state: RootState) => state.member.characterImageUrl
+  const nickname = useSelector(
+    (state: RootState) => state.member.profile.nickname
   );
-  const email = useSelector((state: RootState) => state.member.email);
+  const characterImageUrl = useSelector(
+    (state: RootState) => state.member.profile.characterImageUrl
+  );
+  const email = useSelector((state: RootState) => state.member.profile.email);
 
   useEffect(() => {
     dispatch<any>(fetchMemberInfo());

--- a/app/(main)/my/setting/page.tsx
+++ b/app/(main)/my/setting/page.tsx
@@ -1,37 +1,24 @@
 "use client";
 
 import { logoutUser } from "@/domain/auth/slices/login/loginExtraReducers";
+import { PreviewUrlLabel } from "@/domain/member/components";
 import UploadFileLabel from "@/domain/member/components/UploadFileLabel";
+import { ChangeNicknameType } from "@/domain/member/dto/request";
 import {
   changeNickname,
-  createCharacter,
   fetchMemberInfo,
-  registerCharacter,
 } from "@/domain/member/slices/memberExtraReducers";
-import {
-  clearCharacter,
-  setNickname,
-} from "@/domain/member/slices/memberSlice";
-import {
-  ChangeNicknameType,
-  CreateCharacterType,
-} from "@/domain/member/types/memberRequestType";
-import { setAlert } from "@/domain/noti/slices/notiSlice";
-import { AlertType } from "@/domain/noti/types";
-import path from "@/domain/shared/routes";
+import { setNickname } from "@/domain/member/slices/memberSlice";
 import { RootState } from "@/redux";
 import { Accordion, Button, HR, Label, Modal, TextInput } from "flowbite-react";
-import { useRouter } from "next/navigation";
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 const Page: React.FC = () => {
   const dispatch = useDispatch();
-  const router = useRouter();
-  const email = useSelector((state: RootState) => state.member.email);
-  const nickname = useSelector((state: RootState) => state.member.nickname);
-  const selectedFile = useSelector(
-    (state: RootState) => state.member.selectedFile
+  const email = useSelector((state: RootState) => state.member.profile.email);
+  const nickname = useSelector(
+    (state: RootState) => state.member.profile.nickname
   );
   const [openModal, setOpenModal] = React.useState(false);
 
@@ -46,57 +33,28 @@ const Page: React.FC = () => {
     dispatch<any>(fetchMemberInfo());
   }, []);
 
-  const handleCreateCharacter = async () => {
-    if (!selectedFile) {
-      const data: AlertType = {
-        title: "알림",
-        message: "이미지를 업로드해주세요.",
-        color: "red",
-      };
-      dispatch;
-    }
-    const data: CreateCharacterType = {
-      image: selectedFile,
-    };
-    dispatch<any>(createCharacter(data));
-  };
-
-  const isCreateCharacter = useSelector(
-    (state: RootState) => state.member.isCreateCharacter
-  );
-  const handleSaveCharacter = () => {
-    if (!isCreateCharacter) {
-      const data: AlertType = {
-        title: "알림",
-        message: "캐릭터를 생성해주세요.",
-        color: "red",
-      };
-      dispatch(setAlert(data));
-    }
-    dispatch<any>(registerCharacter());
-  };
-
-  const isRegisterCharacter = useSelector(
-    (state: RootState) => state.member.isRegisterCharacter
-  );
-  useEffect(() => {
-    if (isRegisterCharacter) {
-      const data: AlertType = {
-        title: "알림",
-        message: "캐릭터가 등록되었습니다.",
-        color: "success",
-      };
-      dispatch(setAlert(data));
-      router.push(path.MY);
-      dispatch(clearCharacter());
-    }
-  }, [isRegisterCharacter]);
-
   return (
     <div className="w-full h-screen justify-center">
       <div className="w-full flex justify-center items-center">
         <div className="w-full mt-10">
           <Accordion>
+            <Accordion.Panel>
+              <Accordion.Title>캐릭터 생성하기</Accordion.Title>
+              <Accordion.Content>
+                <div className="flex flex-col justify-center items-center">
+                  <div className="flex flex-col justify-center items-start gap-2">
+                    <Label className="text-gray-500 text-xs">
+                      - 배경이 없는 이미지를 업로드해주세요. <br />
+                      - 얼굴이 선명하게 나온 사진을 사용해주세요. <br />
+                    </Label>
+                    <div className="flex gap-2">
+                      <UploadFileLabel />
+                      <PreviewUrlLabel />
+                    </div>
+                  </div>
+                </div>
+              </Accordion.Content>
+            </Accordion.Panel>
             <Accordion.Panel>
               <Accordion.Title>내 정보</Accordion.Title>
               <Accordion.Content>
@@ -158,36 +116,6 @@ const Page: React.FC = () => {
                       </div>
                     </Modal.Body>
                   </Modal>
-                </div>
-              </Accordion.Content>
-            </Accordion.Panel>
-            <Accordion.Panel>
-              <Accordion.Title>캐릭터 생성하기</Accordion.Title>
-              <Accordion.Content>
-                <div className="flex flex-col justify-center items-center mt-10">
-                  <div className="flex-col justify-center items-center gap-2">
-                    <UploadFileLabel />
-                    <Label className="text-gray-500 text-xs">
-                      - 배경이 없는 이미지를 업로드해주세요. <br />
-                      - 얼굴이 선명하게 나온 사진을 사용해주세요. <br />
-                    </Label>
-                  </div>
-                  <div className="flex gap-2">
-                    <Button
-                      size="md"
-                      className="mt-4"
-                      onClick={handleCreateCharacter}
-                    >
-                      캐릭터 생성하기{" "}
-                    </Button>
-                    <Button
-                      size="md"
-                      className="mt-4"
-                      onClick={handleSaveCharacter}
-                    >
-                      캐릭터 등록하기{" "}
-                    </Button>
-                  </div>
                 </div>
               </Accordion.Content>
             </Accordion.Panel>

--- a/app/(main)/my/setting/page.tsx
+++ b/app/(main)/my/setting/page.tsx
@@ -60,7 +60,7 @@ const Page: React.FC = () => {
               <Accordion.Content>
                 <div>
                   <div className="mb-2 block">
-                    <Label htmlFor="modi-email" value="Email" />
+                    <Label htmlFor="modi-email" value="이메일" />
                   </div>
                   <div className="flex justify-between">
                     <TextInput
@@ -77,7 +77,7 @@ const Page: React.FC = () => {
                 <HR></HR>
                 <div>
                   <div className="mb-2 block">
-                    <Label htmlFor="modi-nickname" value="Nickname" />
+                    <Label htmlFor="modi-nickname" value="닉네임" />
                   </div>
                   <div className="flex justify-between">
                     <TextInput
@@ -94,32 +94,54 @@ const Page: React.FC = () => {
                   </div>
                 </div>
                 <HR />
-                <div className="flex justify-end">
-                  <Button id="logout-button" onClick={() => setOpenModal(true)}>
+                <div className="flex justify-between items-center gap-2">
+                  <div className="mb-2 block">
+                    <Label value="로그아웃" />
+                  </div>
+                  <Button
+                    size="xs"
+                    id="logout-button"
+                    onClick={() => setOpenModal(true)}
+                    className="bg-white text-gray-500 border border-gray-500"
+                  >
                     로그아웃
                   </Button>
-                  <Modal
-                    show={openModal}
-                    onClose={() => {
-                      setOpenModal(false);
-                    }}
+                </div>
+                <HR />
+                <div className="flex justify-between items-center gap-2">
+                  <div className="mb-2 block">
+                    <Label value="회원탈퇴" />
+                  </div>
+                  <Button
+                    size="xs"
+                    id="memberout"
+                    onClick={() => {}}
+                    className="bg-white text-gray-500 border border-gray-500"
                   >
-                    <Modal.Header>토닥토닥</Modal.Header>
-                    <Modal.Body>
-                      <div className="flex justify-between items-center">
-                        <p className="font-semibold text-red-600">
-                          정말 로그아웃 하시겠습니까?
-                        </p>
-                        <Button onClick={() => dispatch<any>(logoutUser())}>
-                          로그아웃
-                        </Button>
-                      </div>
-                    </Modal.Body>
-                  </Modal>
+                    회원탈퇴
+                  </Button>
                 </div>
               </Accordion.Content>
             </Accordion.Panel>
           </Accordion>
+          <Modal
+            show={openModal}
+            onClose={() => {
+              setOpenModal(false);
+            }}
+          >
+            <Modal.Header className="font-gamja">토닥토닥</Modal.Header>
+            <Modal.Body>
+              <div className="flex justify-between items-center">
+                <p className="font-semibold text-red-600">
+                  정말 로그아웃 하시겠습니까?
+                </p>
+                <Button onClick={() => dispatch<any>(logoutUser())}>
+                  로그아웃
+                </Button>
+              </div>
+            </Modal.Body>
+          </Modal>
         </div>
       </div>
     </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,41 +2,15 @@
 
 import { Button } from "flowbite-react";
 import Link from "next/link";
-import dynamic from "next/dynamic";
 import { Logo } from "@/domain/shared/components/layout";
 import path from "@/domain/shared/routes";
 import { useState } from "react";
 import Image from "next/image";
-import { WritingAnimation } from "@/domain/shared/components/lottie-animation";
+// import { WritingAnimation } from "@/domain/shared/components/lottie-animation";
 import {
   PrivacyPolicyModal,
   TermsAndConditionsModal,
 } from "@/domain/auth/components";
-
-const DynamicGraphicAnimation = dynamic(
-  () => import("@/domain/shared/components/lottie-animation/GraphicAnimation"),
-  {
-    ssr: false,
-  }
-);
-const DynamicMusicAnimation = dynamic(
-  () => import("@/domain/shared/components/lottie-animation/MusicAnimation"),
-  {
-    ssr: false,
-  }
-);
-const DynamicShareAnimation = dynamic(
-  () => import("@/domain/shared/components/lottie-animation/ShareAnimation"),
-  {
-    ssr: false,
-  }
-);
-const DynamicWritingAnimation = dynamic(
-  () => import("@/domain/shared/components/lottie-animation/WritingAnimation"),
-  {
-    ssr: false,
-  }
-);
 
 const page = () => {
   const [openTermsModal, setOpenTermsModal] = useState(false);
@@ -70,7 +44,7 @@ const page = () => {
             <Link href={path.LOGIN} className="flex justify-center">
               <Button size="md">시작하기</Button>
             </Link>
-            <WritingAnimation />
+            {/* <WritingAnimation /> */}
           </div>
         </div>
       </main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -30,6 +30,7 @@ const Page = () => {
           alt="background"
           sizes="100vw"
           style={{ width: "100%", height: "100%" }}
+          className="animate-slowPulse"
         />
         <h1 className="w-full flex justify-center">
           <Logo />
@@ -49,7 +50,6 @@ const Page = () => {
             <Link href={path.LOGIN} className="flex justify-center">
               <Button size="md">시작하기</Button>
             </Link>
-            {/* <WritingAnimation /> */}
           </div>
         </div>
       </main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,17 +4,22 @@ import { Button } from "flowbite-react";
 import Link from "next/link";
 import { Logo } from "@/domain/shared/components/layout";
 import path from "@/domain/shared/routes";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
-// import { WritingAnimation } from "@/domain/shared/components/lottie-animation";
 import {
   PrivacyPolicyModal,
   TermsAndConditionsModal,
 } from "@/domain/auth/components";
 
-const page = () => {
+const Page = () => {
   const [openTermsModal, setOpenTermsModal] = useState(false);
   const [openPrivacyModal, setOpenPrivacyModal] = useState(false);
+  useEffect(() => {
+    const token = localStorage.getItem("accessToken");
+    if (token) {
+      window.location.href = path.HOME;
+    }
+  }, []);
   return (
     <div className="w-full flex flex-col min-h-screen justify-center items-center overflow-x-hidden">
       <main className="w-full min-h-screen">
@@ -79,4 +84,4 @@ const page = () => {
   );
 };
 
-export default page;
+export default Page;

--- a/domain/auth/components/LoginForm.tsx
+++ b/domain/auth/components/LoginForm.tsx
@@ -45,10 +45,10 @@ const LoginForm: React.FC = () => {
     <>
       <Label
         onClick={() => dispatch(setIsIdLoginFormView(false))}
-        className="fixed flex top-4 left-4 items-center text-cyan-600 hover:underline dark:text-cyan-500 text-sm"
+        className="fixed flex top-4 left-4 items-center text-gray-200 hover:underline text-sm"
       >
         <DirectionSVG />
-        All sign in options
+        소셜 로그인하기
       </Label>
       <div className="flex justify-center h-full items-center">
         <div className="w-80">
@@ -58,7 +58,7 @@ const LoginForm: React.FC = () => {
           >
             <div>
               <div className="mb-2 block">
-                <Label htmlFor="login-id" value="Login ID" />
+                <Label htmlFor="login-id" value="로그인 아이디" />
               </div>
               <TextInput
                 id="login-id"
@@ -71,7 +71,7 @@ const LoginForm: React.FC = () => {
             </div>
             <div className="mb-2">
               <div className="mb-2 block">
-                <Label htmlFor="password1" value="Password" />
+                <Label htmlFor="password1" value="비밀번호" />
               </div>
               <TextInput
                 id="password1"
@@ -87,20 +87,20 @@ const LoginForm: React.FC = () => {
                 className="text-cyan-600 hover:underline dark:text-cyan-500 text-sm"
                 onClick={() => {}}
               >
-                forgot password?
+                비밀번호를 잊으셨나요?
               </Label>
             </div>
             <Button type="submit" onClick={handleLogin}>
-              Login
+              로그인
             </Button>
             <HR className="mb-0" />
             <Label htmlFor="signup-link" className="flex">
-              Don't have an account?&nbsp;
+              아직 계정이 없으신가요?&nbsp;
               <Link
                 href="/signup"
                 className="text-cyan-600 hover:underline dark:text-cyan-500"
               >
-                Create Account
+                계정 만들기
               </Link>
             </Label>
           </form>

--- a/domain/auth/components/LoginForm.tsx
+++ b/domain/auth/components/LoginForm.tsx
@@ -16,7 +16,6 @@ import { useRouter } from "next/navigation";
 import path from "@/domain/shared/routes";
 import { DirectionSVG } from "@/domain/shared/components/svg";
 import { LoginUserType } from "../dto/request";
-import { setAlert } from "@/domain/noti/slices/notiSlice";
 
 const LoginForm: React.FC = () => {
   const dispatch = useDispatch();
@@ -30,13 +29,6 @@ const LoginForm: React.FC = () => {
     if (isLogin) {
       router.push(path.HOME);
       dispatch(resetLoginState());
-      dispatch(
-        setAlert({
-          title: "알림",
-          message: `로그인 일시: ${new Date().toLocaleString()}`,
-          color: "success",
-        })
-      );
     }
   }, [isLogin]);
 

--- a/domain/auth/components/oauthButton/GoogleLoginButton.tsx
+++ b/domain/auth/components/oauthButton/GoogleLoginButton.tsx
@@ -11,7 +11,7 @@ const GoogleLoginButton: React.FC<ButtonType> = () => {
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="24"
-        height="15"
+        height="24"
         preserveAspectRatio="xMidYMid"
         viewBox="0 0 350 250"
         id="google"
@@ -33,7 +33,7 @@ const GoogleLoginButton: React.FC<ButtonType> = () => {
           d="M130.55 50.479c24.514 0 41.05 10.589 50.479 19.438l36.844-35.974C195.245 12.91 165.798 0 130.55 0 79.49 0 35.393 29.301 13.925 71.947l42.211 32.783c10.59-31.477 39.891-54.251 74.414-54.251"
         ></path>
       </svg>
-      Log in with Google
+      <p className="ml-1 mt-0.5">구글 로그인하기</p>
     </Button>
   );
 };

--- a/domain/auth/components/oauthButton/KakaoLoginButton.tsx
+++ b/domain/auth/components/oauthButton/KakaoLoginButton.tsx
@@ -34,7 +34,7 @@ const KakaoLoginButton: React.FC<ButtonType> = ({ onClick }) => {
           clipRule="evenodd"
         ></path>
       </svg>
-      <p className="ml-1">Log in with Kakao</p>
+      <p className="ml-1 mt-0.5">카카오 로그인하기</p>
     </Button>
   );
 };

--- a/domain/auth/components/oauthButton/NaverLoginButton.tsx
+++ b/domain/auth/components/oauthButton/NaverLoginButton.tsx
@@ -26,7 +26,7 @@ function NaverLoginButton({ onClick }: ButtonType) {
           />
         </g>
       </svg>
-      Log in with Naver
+      네이버 로그인하기
     </button>
   );
 }

--- a/domain/auth/components/oauthButton/OauthLoginGroup.tsx
+++ b/domain/auth/components/oauthButton/OauthLoginGroup.tsx
@@ -11,7 +11,7 @@ import { GoogleLoginButton, KakaoLoginButton, NaverLoginButton } from "..";
 const OauthLoginGroup: React.FC = () => {
   const dispatch = useDispatch();
   const router = useRouter();
-  const url = process.env.NEXT_PUBLIC_API_URL;
+  const url = "http://localhost:8080";
 
   const handleOAuthClick = (provider: string) => {
     if (!url) {

--- a/domain/auth/components/oauthButton/OauthLoginGroup.tsx
+++ b/domain/auth/components/oauthButton/OauthLoginGroup.tsx
@@ -41,14 +41,14 @@ const OauthLoginGroup: React.FC = () => {
         className="w-full"
         onClick={() => dispatch(setIsIdLoginFormView(true))}
       >
-        Log in with ID
+        아이디로 로그인하기
       </Button>
       <br />
       <Button
         className="w-full bg-white border border-gray-300 text-cyan-600 hover:text-white"
         onClick={() => router.push(path.SIGNUP)}
       >
-        Create Account
+        회원가입
       </Button>
     </div>
   );

--- a/domain/auth/components/signupSteps/AccountSection.tsx
+++ b/domain/auth/components/signupSteps/AccountSection.tsx
@@ -79,7 +79,7 @@ const AccountSection: React.FC = () => {
             shadow
           />
           <Button onClick={handleCheckNicknameDuplicate}>
-            {verify.isNicknameVerified ? "✅" : "check"}
+            {verify.isNicknameVerified ? "v" : "check"}
           </Button>
         </div>
       </div>
@@ -101,13 +101,13 @@ const AccountSection: React.FC = () => {
             shadow
           />
           <Button onClick={handleCheckIdDuplicate}>
-            {verify.isSignupIdVerified ? "✅" : "check"}
+            {verify.isSignupIdVerified ? "v" : "check"}
           </Button>
         </div>
       </div>
       <div>
         <div className="mb-2 block">
-          <Label htmlFor="password2" value="Password" />
+          <Label htmlFor="password2" value="Password (8자 이상)" />
         </div>
         <TextInput
           id="password2"
@@ -122,7 +122,7 @@ const AccountSection: React.FC = () => {
         <div className="mb-2 block">
           <Label
             htmlFor="repeat-password"
-            value={`Repeat password ${isSame ? "✅" : "❌"}`}
+            value={`Repeat password ${isSame ? "v" : "x"}`}
           />
         </div>
         <TextInput

--- a/domain/auth/components/signupSteps/AccountSection.tsx
+++ b/domain/auth/components/signupSteps/AccountSection.tsx
@@ -63,7 +63,7 @@ const AccountSection: React.FC = () => {
     >
       <div>
         <div className="mb-2 block">
-          <Label htmlFor="nickname" value="Nickname" />
+          <Label htmlFor="nickname" value="닉네임" />
         </div>
         <div className="flex justify-between">
           <TextInput
@@ -79,13 +79,13 @@ const AccountSection: React.FC = () => {
             shadow
           />
           <Button onClick={handleCheckNicknameDuplicate}>
-            {verify.isNicknameVerified ? "v" : "check"}
+            {verify.isNicknameVerified ? "v" : "확인"}
           </Button>
         </div>
       </div>
       <div>
         <div className="mb-2 block">
-          <Label htmlFor="signup-id" value="Login ID" />
+          <Label htmlFor="signup-id" value="로그인 아이디" />
         </div>
         <div className="flex justify-between">
           <TextInput
@@ -101,13 +101,13 @@ const AccountSection: React.FC = () => {
             shadow
           />
           <Button onClick={handleCheckIdDuplicate}>
-            {verify.isSignupIdVerified ? "v" : "check"}
+            {verify.isSignupIdVerified ? "v" : "확인"}
           </Button>
         </div>
       </div>
       <div>
         <div className="mb-2 block">
-          <Label htmlFor="password2" value="Password (8자 이상)" />
+          <Label htmlFor="password2" value="비밀번호 (8자 이상)" />
         </div>
         <TextInput
           id="password2"
@@ -122,7 +122,7 @@ const AccountSection: React.FC = () => {
         <div className="mb-2 block">
           <Label
             htmlFor="repeat-password"
-            value={`Repeat password ${isSame ? "v" : "x"}`}
+            value={`비밀번호 재입력 ${isSame ? "" : "일치하지 않습니다."}`}
           />
         </div>
         <TextInput

--- a/domain/auth/components/signupSteps/PersonalSection.tsx
+++ b/domain/auth/components/signupSteps/PersonalSection.tsx
@@ -2,7 +2,7 @@
 
 import { RootState } from "@/redux";
 import { Button, Label, TextInput } from "flowbite-react";
-import React from "react";
+import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
   confirmEmailCode,
@@ -15,6 +15,7 @@ import {
   setOTP,
   setSignupEmail,
 } from "../../slices/signup/signupSlice";
+import { setAlert } from "@/domain/noti/slices/notiSlice";
 
 const PersonalSection: React.FC = () => {
   const dispatch = useDispatch();
@@ -43,6 +44,34 @@ const PersonalSection: React.FC = () => {
     );
   };
 
+  const isEmailVerified = useSelector(
+    (state: RootState) => state.signup.verify.isEmailVerified
+  );
+  useEffect(() => {
+    if (!isEmailVerified) return;
+    dispatch(
+      setAlert({
+        title: "알림",
+        message: "이메일을 전송했습니다. 확인해주세요.",
+        color: "info",
+      })
+    );
+  }, [isEmailVerified]);
+
+  const isOtpVerified = useSelector(
+    (state: RootState) => state.signup.verify.isOtpVerified
+  );
+  useEffect(() => {
+    if (!isOtpVerified) return;
+    dispatch(
+      setAlert({
+        title: "알림",
+        message: "OTP 인증에 성공했습니다.",
+        color: "success",
+      })
+    );
+  }, [isOtpVerified]);
+
   return (
     <section
       className={`${
@@ -66,7 +95,7 @@ const PersonalSection: React.FC = () => {
           shadow
         />
         <Button onClick={handleVerifyEmail}>
-          {verify.isEmailVerified ? "✅" : "verify"}
+          {verify.isEmailVerified ? "v" : "verify"}
         </Button>
       </div>
       <div className="mb-2 block">
@@ -86,7 +115,7 @@ const PersonalSection: React.FC = () => {
           shadow
         />
         <Button onClick={handleConfirmEmailCode}>
-          {verify.isOtpVerified ? "✅" : "check"}
+          {verify.isOtpVerified ? "v" : "check"}
         </Button>
       </div>
     </section>

--- a/domain/auth/components/signupSteps/PersonalSection.tsx
+++ b/domain/auth/components/signupSteps/PersonalSection.tsx
@@ -79,7 +79,7 @@ const PersonalSection: React.FC = () => {
       } space-y-2`}
     >
       <div className="mb-2 block">
-        <Label htmlFor="email2" value="Email" />
+        <Label htmlFor="email2" value="이메일" />
       </div>
       <div className="flex justify-between">
         <TextInput
@@ -95,11 +95,11 @@ const PersonalSection: React.FC = () => {
           shadow
         />
         <Button onClick={handleVerifyEmail}>
-          {verify.isEmailVerified ? "v" : "verify"}
+          {verify.isEmailVerified ? "v" : "전송"}
         </Button>
       </div>
       <div className="mb-2 block">
-        <Label htmlFor="otp" value="OTP" />
+        <Label htmlFor="otp" value="인증번호" />
       </div>
       <div className="flex justify-between">
         <TextInput
@@ -115,7 +115,7 @@ const PersonalSection: React.FC = () => {
           shadow
         />
         <Button onClick={handleConfirmEmailCode}>
-          {verify.isOtpVerified ? "v" : "check"}
+          {verify.isOtpVerified ? "v" : "확인"}
         </Button>
       </div>
     </section>

--- a/domain/auth/components/signupSteps/PolicySection.tsx
+++ b/domain/auth/components/signupSteps/PolicySection.tsx
@@ -27,38 +27,38 @@ const PolicySection: React.FC = () => {
     >
       <div className="flex items-center gap-2">
         <Checkbox
-          id="agree"
+          id="agreeTerms"
           onChange={(e) => dispatch(setIsTermsAgreed(e.target.checked))}
           required
         />
-        <Label htmlFor="agree" className="flex">
-          I agree with the&nbsp;
+        <Label htmlFor="agreeTerms" className="flex">
           <p
             onClick={() => setOpenTermsModal(true)}
             className="text-cyan-600 hover:underline dark:text-cyan-500 underline"
           >
-            terms and conditions
+            서비스 이용약관&nbsp;
           </p>
           <TermsAndConditionsModal
             open={openTermsModal}
             onClose={() => setOpenTermsModal(false)}
           />
+          에 동의합니다.
         </Label>
       </div>
       <div className="flex items-center gap-2">
         <Checkbox
-          id="agree"
+          id="agreePolicy"
           onChange={(e) => dispatch(setIsPrivacyAgreed(e.target.checked))}
           required
         />
-        <Label htmlFor="agree" className="flex">
-          I agree with the&nbsp;
+        <Label htmlFor="agreePolicy" className="flex">
           <p
             onClick={() => setOpenPrivacyModal(true)}
             className="text-cyan-600 hover:underline dark:text-cyan-500 underline"
           >
-            privacy policy
+            개인정보처리방침&nbsp;
           </p>
+          에 동의합니다.
           <PrivacyPolicyModal
             open={openPrivacyModal}
             onClose={() => setOpenPrivacyModal(false)}

--- a/domain/auth/components/signupSteps/SignupStepper.tsx
+++ b/domain/auth/components/signupSteps/SignupStepper.tsx
@@ -9,7 +9,7 @@ import { SIGNUP_STEP } from "../../constants";
 const SignupStepper: React.FC = () => {
   const signupStep = useSelector((state: RootState) => state.signup.step);
   return (
-    <ol className="flex items-center w-full p-3 space-x-2 text-sm font-medium text-center text-gray-500 bg-white border border-gray-200 rounded-lg shadow-sm dark:text-gray-400 dark:bg-gray-800 dark:border-gray-700">
+    <ol className="flex justify-center items-center w-full p-3 space-x-2 text-sm font-medium text-center text-gray-500 bg-white border border-gray-200 rounded-lg shadow-sm dark:text-gray-400 dark:bg-gray-800 dark:border-gray-700">
       <li
         className={`flex items-center ${
           signupStep >= SIGNUP_STEP.PERSONAL
@@ -26,7 +26,7 @@ const SignupStepper: React.FC = () => {
         >
           1
         </span>
-        Personal
+        이메일
         <RedirectSVG />
       </li>
       <li
@@ -45,7 +45,7 @@ const SignupStepper: React.FC = () => {
         >
           2
         </span>
-        Account
+        계정
         <RedirectSVG />
       </li>
       <li
@@ -64,7 +64,7 @@ const SignupStepper: React.FC = () => {
         >
           3
         </span>
-        Policy
+        약관동의
       </li>
     </ol>
   );

--- a/domain/auth/dto/request/confirmEmailCodeDto.ts
+++ b/domain/auth/dto/request/confirmEmailCodeDto.ts
@@ -10,6 +10,7 @@ export class ConfirmEmailCodeRequestDto implements ConfirmEmailCodeType {
   public emailOtp: string;
 
   constructor(params: ConfirmEmailCodeType) {
+    if (!params.emailOtp) throw new Error("otp값을 입력해주세요.");
     this.email = params.email;
     this.emailOtp = params.emailOtp.trim(); // OTP의 앞뒤 공백 제거
   }

--- a/domain/auth/dto/request/registerUserDto.ts
+++ b/domain/auth/dto/request/registerUserDto.ts
@@ -22,8 +22,7 @@ export class RegisterUserRequestDto implements RegisterUserType {
       throw new Error("이메일 형식이 올바르지 않습니다.");
     if (!nickname) throw new Error("닉네임을 필수로 입력해주세요.");
     if (!loginId) throw new Error("로그인 아이디를 필수로 입력해주세요.");
-    if (!password || password.length < 8)
-      throw new Error("패스워드는 8자 이상이어야 합니다.");
+    if (!password) throw new Error("패스워드가 비어있습니다.");
 
     this.email = email.trim().toLowerCase();
     this.nickname = nickname.trim();

--- a/domain/auth/function/validate.ts
+++ b/domain/auth/function/validate.ts
@@ -2,35 +2,60 @@ import { setAlert } from "@/domain/noti/slices/notiSlice";
 import { SIGNUP_STEP } from "../constants";
 import { setSignupStep } from "../slices/signup/signupSlice";
 
-// 각 단계별 검증 로직을 별도 함수로 분리
-const validatePersonalStep = (verify: any) => {
-  return verify.isEmailVerified && verify.isOtpVerified;
+const PERSONAL_STEP_ERRORS = {
+  email: "이메일 인증이 필요합니다",
+  otp: "OTP 인증이 필요합니다",
+} as const;
+
+const validatePersonalStep = (
+  verify: any
+): { isValid: boolean; error?: string } => {
+  if (!verify.isEmailVerified)
+    return { isValid: false, error: PERSONAL_STEP_ERRORS.email };
+  if (!verify.isOtpVerified)
+    return { isValid: false, error: PERSONAL_STEP_ERRORS.otp };
+  return { isValid: true };
 };
+
+const ACCOUNT_STEP_ERRORS = {
+  nickname: "닉네임 중복 확인이 필요합니다",
+  id: "아이디 중복 확인이 필요합니다",
+  password: "비밀번호가 일치하지 않습니다",
+  passwordSize: "비밀번호 길이는 최소 8자 이상이어야 합니다.",
+} as const;
 
 const validateAccountStep = (
   verify: any,
   password: string,
   reEnterPassword: string
-) => {
-  return (
-    verify.isNicknameVerified &&
-    verify.isSignupIdVerified &&
-    password === reEnterPassword
-  );
+): { isValid: boolean; error?: string } => {
+  if (!verify.isNicknameVerified)
+    return { isValid: false, error: ACCOUNT_STEP_ERRORS.nickname };
+  if (!verify.isSignupIdVerified)
+    return { isValid: false, error: ACCOUNT_STEP_ERRORS.id };
+  if (password !== reEnterPassword)
+    return { isValid: false, error: ACCOUNT_STEP_ERRORS.password };
+  if (password.length < 8) {
+    return { isValid: false, error: ACCOUNT_STEP_ERRORS.passwordSize };
+  }
+  return { isValid: true };
 };
 
-const validatePolicyStep = (verify: any) => {
-  return verify.isTermsAgreed && verify.isPrivacyAgreed;
-};
-
-// 알림 메시지 상수화
-const STEP_ERROR_MESSAGES = {
-  [SIGNUP_STEP.PERSONAL]: "이메일을 인증해주세요",
-  [SIGNUP_STEP.ACCOUNT]: "입력값을 확인해주세요",
-  [SIGNUP_STEP.POLICY]: "전체 약관에 동의해주세요",
+const POLICY_STEP_ERRORS = {
+  terms: "서비스 이용약관 동의가 필요합니다",
+  privacy: "개인정보 처리방침 동의가 필요합니다",
 } as const;
 
-// 메인 핸들러 함수 단순화
+const validatePolicyStep = (
+  verify: any
+): { isValid: boolean; error?: string } => {
+  if (!verify.isTermsAgreed)
+    return { isValid: false, error: POLICY_STEP_ERRORS.terms };
+  if (!verify.isPrivacyAgreed)
+    return { isValid: false, error: POLICY_STEP_ERRORS.privacy };
+  return { isValid: true };
+};
+
 const handleSwitchSignupStep = ({
   postSignup,
   verify,
@@ -46,19 +71,20 @@ const handleSwitchSignupStep = ({
   signupStep: SIGNUP_STEP;
   dispatch: any;
 }) => {
-  const stepValidators: { [key in SIGNUP_STEP]: () => boolean } = {
+  const stepValidators = {
     [SIGNUP_STEP.PERSONAL]: () => validatePersonalStep(verify),
     [SIGNUP_STEP.ACCOUNT]: () =>
       validateAccountStep(verify, password, reEnterPassword),
     [SIGNUP_STEP.POLICY]: () => validatePolicyStep(verify),
   };
-  const isValid = stepValidators[signupStep]();
 
-  if (!isValid) {
+  const validationResult = stepValidators[signupStep]();
+
+  if (!validationResult.isValid) {
     dispatch(
       setAlert({
         title: "알림",
-        message: STEP_ERROR_MESSAGES[signupStep],
+        message: validationResult.error || "",
         color: "info",
       })
     );

--- a/domain/auth/mocks/auth.ts
+++ b/domain/auth/mocks/auth.ts
@@ -38,16 +38,17 @@ export const authMockups = [
 
   // 로그아웃 (성공 및 에러 응답 처리)
   http.post(url + "/auth/logout", () => {
-    return new HttpResponse(
-      JSON.stringify({
-        title: "TEMP_USER_DIARY_CREATE_FAIL",
-        message: "로그아웃할 수 없습니다.",
-      }),
-      {
-        status: 404,
-        headers: { "Content-Type": "application/json" },
-      }
-    );
+    // return new HttpResponse(
+    //   JSON.stringify({
+    //     title: "TEMP_USER_DIARY_CREATE_FAIL",
+    //     message: "로그아웃할 수 없습니다.",
+    //   }),
+    //   {
+    //     status: 404,
+    //     headers: { "Content-Type": "application/json" },
+    //   }
+    // );
+    return new HttpResponse(null, { status: 204 });
   }),
 
   // 회원 탈퇴

--- a/domain/auth/mocks/auth.ts
+++ b/domain/auth/mocks/auth.ts
@@ -36,9 +36,18 @@ export const authMockups = [
     });
   }),
 
-  // 로그아웃
+  // 로그아웃 (성공 및 에러 응답 처리)
   http.post(url + "/auth/logout", () => {
-    return new HttpResponse(null, { status: 204 });
+    return new HttpResponse(
+      JSON.stringify({
+        title: "TEMP_USER_DIARY_CREATE_FAIL",
+        message: "로그아웃할 수 없습니다.",
+      }),
+      {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
   }),
 
   // 회원 탈퇴

--- a/domain/auth/slices/login/loginExtraReducers.ts
+++ b/domain/auth/slices/login/loginExtraReducers.ts
@@ -1,8 +1,4 @@
-import {
-  ActionReducerMapBuilder,
-  createAsyncThunk,
-  PayloadAction,
-} from "@reduxjs/toolkit";
+import { ActionReducerMapBuilder, PayloadAction } from "@reduxjs/toolkit";
 import { LoginState } from "./loginSlice";
 import axiosInstance from "@/domain/shared/axios";
 import { LoginUserRequestDto, LoginUserType } from "@/domain/auth/dto/request";
@@ -11,9 +7,10 @@ import {
   ReIssueTokenResponseDto,
   ReIssueTokenType,
 } from "../../dto/response/reIssueTokenDto";
+import createCustomAsyncThunk from "@/redux/createCustomAsyncThunk";
 
 // 로그인 -----------------------------------------------------
-export const loginUser = createAsyncThunk(
+export const loginUser = createCustomAsyncThunk(
   "login/loginUser",
   async (data: LoginUserType) => {
     const loginUserDto = new LoginUserRequestDto(data);
@@ -46,12 +43,12 @@ const addLoginUser = (builder: ActionReducerMapBuilder<LoginState>) => {
   builder.addCase(loginUser.rejected, (state, action) => {
     state.isLogin = false;
     state.loading = false;
-    state.error = action.error.message ?? null;
+    state.error = action.payload?.message ?? null;
   });
 };
 
 // 로그아웃 -----------------------------------------------------
-export const logoutUser = createAsyncThunk("login/logout", async () => {
+export const logoutUser = createCustomAsyncThunk("login/logout", async () => {
   const response = await axiosInstance.post("/auth/logout");
   return response.data;
 });
@@ -68,12 +65,12 @@ const addLogoutUser = (builder: ActionReducerMapBuilder<LoginState>) => {
   });
   builder.addCase(logoutUser.rejected, (state, action) => {
     state.loading = false;
-    state.error = action.error.message ?? null;
+    state.error = action.payload?.message ?? null;
   });
 };
 
 // 토큰 재발급 -----------------------------------------------------
-export const reissueToken = createAsyncThunk(
+export const reissueToken = createCustomAsyncThunk(
   "signup/reissueToken",
   async () => {
     const response = await axiosInstance.post("/auth/refresh-token");
@@ -96,7 +93,7 @@ const addReissueToken = (builder: ActionReducerMapBuilder<LoginState>) => {
   );
   builder.addCase(reissueToken.rejected, (state, action) => {
     state.loading = false;
-    state.error = action.error.message ?? "";
+    state.error = action.payload?.message ?? "";
   });
 };
 

--- a/domain/auth/slices/login/loginExtraReducers.ts
+++ b/domain/auth/slices/login/loginExtraReducers.ts
@@ -8,6 +8,7 @@ import {
   ReIssueTokenType,
 } from "../../dto/response/reIssueTokenDto";
 import createCustomAsyncThunk from "@/redux/createCustomAsyncThunk";
+import path from "@/domain/shared/routes";
 
 // 로그인 -----------------------------------------------------
 export const loginUser = createCustomAsyncThunk(
@@ -61,6 +62,8 @@ const addLogoutUser = (builder: ActionReducerMapBuilder<LoginState>) => {
   builder.addCase(logoutUser.fulfilled, (state, action) => {
     state.isLogin = false;
     localStorage.removeItem("accessToken");
+    localStorage.removeItem("lastLogin");
+    window.location.href = path.LOGIN;
     state.loading = false;
   });
   builder.addCase(logoutUser.rejected, (state, action) => {

--- a/domain/auth/slices/signup/signupExtraReducers.ts
+++ b/domain/auth/slices/signup/signupExtraReducers.ts
@@ -1,6 +1,7 @@
-import { ActionReducerMapBuilder, createAsyncThunk } from "@reduxjs/toolkit";
+import { ActionReducerMapBuilder } from "@reduxjs/toolkit";
 import { SignupState } from "./signupSlice";
 import axiosInstance from "@/domain/shared/axios";
+import createCustomAsyncThunk from "@/redux/createCustomAsyncThunk";
 import {
   CheckIdDuplicateRequestDto,
   CheckIdDuplicateType,
@@ -15,7 +16,7 @@ import {
 } from "../../dto/request";
 
 // 이메일 인증 -----------------------------------------------------
-export const verifyEmail = createAsyncThunk(
+export const verifyEmail = createCustomAsyncThunk(
   "signup/verifyEmail",
   async (data: VerifyEmailType) => {
     const verifyEmailDto = new VerifyEmailRequestDto(data.email);
@@ -39,12 +40,12 @@ const addVerifyEmail = (builder: ActionReducerMapBuilder<SignupState>) => {
   builder.addCase(verifyEmail.rejected, (state, action) => {
     state.verify.isEmailVerified = false;
     state.loading = false;
-    state.error = action.error.message ?? null;
+    state.error = action.payload?.message ?? null;
   });
 };
 
 // 이메일 인증번호 확인 -----------------------------------------------------
-export const confirmEmailCode = createAsyncThunk(
+export const confirmEmailCode = createCustomAsyncThunk(
   "signup/confirmEmailCode",
   async (data: ConfirmEmailCodeType) => {
     const confirmEmailCodeDto = new ConfirmEmailCodeRequestDto(data);
@@ -68,12 +69,12 @@ const addConfirmEmailCode = (builder: ActionReducerMapBuilder<SignupState>) => {
   builder.addCase(confirmEmailCode.rejected, (state, action) => {
     state.verify.isOtpVerified = false;
     state.loading = false;
-    state.error = action.error.message ?? null;
+    state.error = action.payload?.message ?? null;
   });
 };
 
 // 닉네임 중복 확인 -----------------------------------------------------
-export const checkNicknameDuplicate = createAsyncThunk(
+export const checkNicknameDuplicate = createCustomAsyncThunk(
   "signup/checkNicknameDuplicate",
   async (data: CheckNicknameDuplicateType) => {
     const checkNickNameDuplicateDto = new CheckNicknameDuplicateRequestDto(
@@ -101,12 +102,12 @@ const addCheckNicknameDuplicate = (
   builder.addCase(checkNicknameDuplicate.rejected, (state, action) => {
     state.verify.isNicknameVerified = false;
     state.loading = false;
-    state.error = action.error.message ?? null;
+    state.error = action.payload?.message ?? null;
   });
 };
 
 // ID 중복 확인 -----------------------------------------------------
-export const checkIdDuplicate = createAsyncThunk(
+export const checkIdDuplicate = createCustomAsyncThunk(
   "signup/checkIdDuplicate",
   async (data: CheckIdDuplicateType) => {
     const checkIdDuplicateDto = new CheckIdDuplicateRequestDto(data.loginId);
@@ -130,12 +131,12 @@ const addcheckIdDuplicate = (builder: ActionReducerMapBuilder<SignupState>) => {
   builder.addCase(checkIdDuplicate.rejected, (state, action) => {
     state.verify.isSignupIdVerified = false;
     state.loading = false;
-    state.error = action.error.message ?? null;
+    state.error = action.payload?.message ?? null;
   });
 };
 
 // 회원가입 -----------------------------------------------------
-export const registerUser = createAsyncThunk(
+export const registerUser = createCustomAsyncThunk(
   "signup/registerUser",
   async (data: RegisterUserType) => {
     const registerUserDto = new RegisterUserRequestDto(data);
@@ -159,12 +160,12 @@ const addRegisterUser = (builder: ActionReducerMapBuilder<SignupState>) => {
   builder.addCase(registerUser.rejected, (state, action) => {
     state.isSignup = false;
     state.loading = false;
-    state.error = action.error.message ?? null;
+    state.error = action.payload?.message ?? null;
   });
 };
 
 // 회원탈퇴 -----------------------------------------------------
-export const deleteAccount = createAsyncThunk(
+export const deleteAccount = createCustomAsyncThunk(
   "signup/deleteAccount",
   async () => {
     const response = await axiosInstance.post("/auth/deactivate");
@@ -183,7 +184,7 @@ const addDeleteAccount = (builder: ActionReducerMapBuilder<SignupState>) => {
   });
   builder.addCase(deleteAccount.rejected, (state, action) => {
     state.loading = false;
-    state.error = action.error.message ?? null;
+    state.error = action.payload?.message ?? null;
   });
 };
 

--- a/domain/diary/components/Calendar.tsx
+++ b/domain/diary/components/Calendar.tsx
@@ -57,6 +57,11 @@ const MyCalendar: React.FC = () => {
       onActiveStartDateChange={onActiveStartDateChange}
       className="w-full p-2 max-w-md space-y-2 bg-white border border-gray-200 rounded-md"
       tileClassName="flex text-center p-4 border border-gray-100 hover:bg-cyan-500 rounded-sm text-gray-700"
+      // 요일, 한국어 표시
+      formatShortWeekday={(locale, date) =>
+        date.toLocaleDateString("ko-KR", { weekday: "short" }).charAt(0)
+      }
+      // 상단 연월 표시기
       navigationLabel={({ date }) => (
         <span className="flex text-lg font-semibold p-4">
           {date.toLocaleString("ko-KR", {
@@ -65,6 +70,7 @@ const MyCalendar: React.FC = () => {
           })}
         </span>
       )}
+      // 개별요소 내부
       tileContent={({ date }) =>
         isIncludeDiaryStatusList(date) ? (
           <div className="w-1.5 h-1.5 rounded-full bg-cyan-500 animate-pulse" />

--- a/domain/diary/components/Calendar.tsx
+++ b/domain/diary/components/Calendar.tsx
@@ -21,7 +21,7 @@ const MyCalendar: React.FC = () => {
   );
 
   const onChange = (newDate: any) => {
-    router.push(`${path.READ}?date=${toKSTISOString(newDate)}`);
+    router.push(`${path.READ}?date=${toKSTISOString(newDate).slice(0, 10)}`);
   };
 
   const onActiveStartDateChange = ({
@@ -40,10 +40,12 @@ const MyCalendar: React.FC = () => {
   }, [viewDate]);
 
   const isIncludeDiaryStatusList = (date: Date) => {
-    return diaryStatusList.some(
-      (status: DiaryStatusType) =>
-        date.toISOString().split("T")[0] === status.date
-    );
+    return diaryStatusList.some((status: DiaryStatusType) => {
+      const serverDate = new Date(`${status.date}T00:00:00+09:00`);
+      if (date.toLocaleDateString() == serverDate.toLocaleDateString()) {
+        return true;
+      }
+    });
   };
   return (
     <Calendar

--- a/domain/diary/components/KoDatePicker.tsx
+++ b/domain/diary/components/KoDatePicker.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { Datepicker } from "flowbite-react";
+import React from "react";
+
+interface KoDatepickerProps {
+  className?: string;
+  onChange?: (date: Date | null) => void;
+}
+
+const KoDatepicker: React.FC<KoDatepickerProps> = ({ className, onChange }) => {
+  return (
+    <Datepicker
+      className="z-50"
+      onChange={onChange}
+      autoHide={true}
+      language="korea"
+      weekStart={1}
+    />
+  );
+};
+
+export default KoDatepicker;

--- a/domain/diary/components/ShareDiary.tsx
+++ b/domain/diary/components/ShareDiary.tsx
@@ -25,7 +25,7 @@ const ShareDiary: React.FC = () => {
 
   const handleChage = (date: Date | null) => {
     if (!date) return;
-    dispatch<any>(fetchDiaryDetail(date!.toISOString()));
+    dispatch<any>(fetchDiaryDetail(date!.toISOString().slice(0, -1))); // 나중에 z를 제거하도록 포맷 통일
   };
 
   const handleUpload = () => {
@@ -45,16 +45,16 @@ const ShareDiary: React.FC = () => {
   };
 
   const handleOpenShareModal = () => {
-    if (!isAiContentGenerated()) {
-      dispatch(
-        setAlert({
-          title: "알림",
-          message: "게시물이 아직 생성되지 않았습니다. 조금만 기다려주세요.",
-          color: "info",
-        })
-      );
-      return;
-    }
+    // if (!isAiContentGenerated()) {
+    //   dispatch(
+    //     setAlert({
+    //       title: "알림",
+    //       message: "게시물이 아직 생성되지 않았습니다. 조금만 기다려주세요.",
+    //       color: "info",
+    //     })
+    //   );
+    //   return;
+    // }
     setOpenShareModal(true);
   };
 

--- a/domain/diary/components/ShareDiary.tsx
+++ b/domain/diary/components/ShareDiary.tsx
@@ -10,7 +10,7 @@ import { uploadFeed } from "@/domain/feed/slices/feedExtraReducers";
 import { DiaryResponseType } from "../dto/response";
 import { UploadFeedType } from "@/domain/feed/dto/request";
 import { CarouselAudioEmoji } from "@/domain/shared/components";
-import { setAlert } from "@/domain/noti/slices/notiSlice";
+import KoDatepicker from "./KoDatePicker";
 
 const ShareDiary: React.FC = () => {
   const dispatch = useDispatch();
@@ -23,7 +23,7 @@ const ShareDiary: React.FC = () => {
     (state: any) => state.diary.queriedDiary
   );
 
-  const handleChage = (date: Date | null) => {
+  const handleDateChage = (date: Date | null) => {
     if (!date) return;
     dispatch<any>(fetchDiaryDetail(date!.toISOString().slice(0, -1))); // 나중에 z를 제거하도록 포맷 통일
   };
@@ -61,7 +61,7 @@ const ShareDiary: React.FC = () => {
   return (
     <>
       <div className="flex justify-between items-center mb-2">
-        <Datepicker className="z-50" onChange={handleChage} autoHide={true} />
+        <KoDatepicker className="z-50" onChange={handleDateChage} />
         <Button
           onClick={handleOpenShareModal}
           className="flex justify-end items-center h-10"
@@ -82,7 +82,7 @@ const ShareDiary: React.FC = () => {
         ) : null}
       </>
       <Modal show={openShareModal} onClose={() => setOpenShareModal(false)}>
-        <Modal.Header>토닥토닥</Modal.Header>
+        <Modal.Header className="font-gamja">토닥토닥</Modal.Header>
         <Modal.Body>
           <div className="space-y-6">
             <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">

--- a/domain/diary/components/index.ts
+++ b/domain/diary/components/index.ts
@@ -3,4 +3,12 @@ import Calendar from "react-calendar";
 import FeedMessageForm from "./FeedMessageForm";
 import AlertButton from "./AlertButton";
 import TypingText from "./TypingText";
-export { Calendar, ShareDiary, FeedMessageForm, AlertButton, TypingText };
+import KoDatepicker from "./KoDatePicker";
+export {
+  Calendar,
+  ShareDiary,
+  FeedMessageForm,
+  AlertButton,
+  TypingText,
+  KoDatepicker,
+};

--- a/domain/diary/slices/diaryExtraReducers.ts
+++ b/domain/diary/slices/diaryExtraReducers.ts
@@ -1,10 +1,7 @@
-import {
-  ActionReducerMapBuilder,
-  createAsyncThunk,
-  PayloadAction,
-} from "@reduxjs/toolkit";
+import { ActionReducerMapBuilder, PayloadAction } from "@reduxjs/toolkit";
 import { DiaryState } from "./diarySlice";
 import axiosInstance from "@/domain/shared/axios";
+import createCustomAsyncThunk from "@/redux/createCustomAsyncThunk";
 import {
   CreateDiaryEntryRequestDto,
   CreateDiaryEntryType,
@@ -19,7 +16,7 @@ import {
 } from "../dto/response";
 
 // 나의 일기 상세 조회 -----------------------------------------------------
-export const fetchDiaryDetail = createAsyncThunk(
+export const fetchDiaryDetail = createCustomAsyncThunk(
   "diary/fetchDiaryDetail",
   async (params: string) => {
     const response = await axiosInstance.get(`/diary/my/detail?date=${params}`);
@@ -42,12 +39,12 @@ const addFetchDiaryDetail = (builder: ActionReducerMapBuilder<DiaryState>) => {
   );
   builder.addCase(fetchDiaryDetail.rejected, (state, action) => {
     state.loading = false;
-    state.error = action.error.message ?? null;
+    state.error = action.payload?.message ?? null;
   });
 };
 
 // 연월 일기 작성 현황 확인 -----------------------------------------------------
-export const fetchDiaryStatus = createAsyncThunk(
+export const fetchDiaryStatus = createCustomAsyncThunk(
   "diary/fetchDiaryStatus",
   async (params: string) => {
     const response = await axiosInstance.get(`/diary/my?yearMonth=${params}`);
@@ -71,7 +68,7 @@ const addFetchDiaryStatus = (builder: ActionReducerMapBuilder<DiaryState>) => {
 };
 
 // 일기 작성 -----------------------------------------------------
-export const createDiaryEntry = createAsyncThunk(
+export const createDiaryEntry = createCustomAsyncThunk(
   "diary/createDiaryEntry",
   async (data: CreateDiaryEntryType) => {
     const createDiaryEntryDto = new CreateDiaryEntryRequestDto(data);
@@ -100,12 +97,12 @@ const addCreateDiaryEntry = (builder: ActionReducerMapBuilder<DiaryState>) => {
   );
   builder.addCase(createDiaryEntry.rejected, (state, action) => {
     state.loading = false;
-    state.error = action.error.message ?? null;
+    state.error = action.payload?.message ?? null;
   });
 };
 
 // 일기 삭제 -----------------------------------------------------
-export const deleteDiaryEntry = createAsyncThunk(
+export const deleteDiaryEntry = createCustomAsyncThunk(
   "diary/deleteDiaryEntry",
   async (data: DeleteDiaryEntryType) => {
     const deleteDiaryEntryDto = new DeleteDiaryEntryRequestDto(data);
@@ -126,7 +123,7 @@ const addDeleteDiaryEntry = (builder: ActionReducerMapBuilder<DiaryState>) => {
   });
   builder.addCase(deleteDiaryEntry.rejected, (state, action) => {
     state.loading = false;
-    state.error = action.error.message ?? null;
+    state.error = action.payload?.message ?? null;
   });
 };
 

--- a/domain/diary/slices/diarySlice.ts
+++ b/domain/diary/slices/diarySlice.ts
@@ -28,7 +28,7 @@ const diarySlice = createSlice({
   name: "diarySlice",
   initialState,
   reducers: {
-    setCommentView: (state, action: PayloadAction<boolean>) => {
+    setAiCommentView: (state, action: PayloadAction<boolean>) => {
       state.commentView = action.payload;
     },
     clearAiCommet: (state) => {
@@ -38,6 +38,6 @@ const diarySlice = createSlice({
   extraReducers: (builder: any) => addDiaryExtraReducers(builder),
 });
 
-export const { clearAiCommet, setCommentView } = diarySlice.actions;
+export const { clearAiCommet, setAiCommentView } = diarySlice.actions;
 export const extraReducers = diarySlice.reducer;
 export default diarySlice.reducer;

--- a/domain/feed/components/Feed.tsx
+++ b/domain/feed/components/Feed.tsx
@@ -11,6 +11,7 @@ const Feed: React.FC<FeedType> = ({
   reactionCount,
   myReaction,
   diaryId,
+  publicContent,
 }) => {
   return (
     <div className="flex-col w-full max-w-md border-b border-gray-200">
@@ -28,7 +29,7 @@ const Feed: React.FC<FeedType> = ({
       />
       <div className="mb-10">
         <p className="w-full border-none text-sm bg-white font-mono m-2">
-          안녕하세요. 고양이 사진입니다.
+          {publicContent}
         </p>
       </div>
     </div>

--- a/domain/feed/mocks/feed.ts
+++ b/domain/feed/mocks/feed.ts
@@ -55,7 +55,7 @@ export const feedMockups = [
   // 나의 공개 일기 불러오기(무한 스크롤)
   http.get(url + "/diary/my/shared", () => {
     return HttpResponse.json({
-      diaries: [
+      sharedDiaries: [
         {
           publicDiaryId: 13, // public diary,
           webtoonImageUrl: "/minion2.png", // diary

--- a/domain/feed/slices/feedExtraReducers.ts
+++ b/domain/feed/slices/feedExtraReducers.ts
@@ -106,7 +106,7 @@ const addFetchMyFeedEntries = (builder: ActionReducerMapBuilder<FeedState>) => {
     state.error = null;
   });
   builder.addCase(fetchMyFeedEntries.fulfilled, (state, action) => {
-    state.myFeedList = [...state.myFeedList, ...action.payload.diaries];
+    state.myFeedList = [...state.myFeedList, ...action.payload.sharedDiaries];
     state.myFeedAfter = action.payload.after;
     state.myFeedEnd = action.payload.isEnd;
     state.loading = false;

--- a/domain/feed/slices/feedExtraReducers.ts
+++ b/domain/feed/slices/feedExtraReducers.ts
@@ -1,5 +1,6 @@
-import { ActionReducerMapBuilder, createAsyncThunk } from "@reduxjs/toolkit";
+import { ActionReducerMapBuilder } from "@reduxjs/toolkit";
 import { FeedState } from "./feedSlice";
+import createCustomAsyncThunk from "@/redux/createCustomAsyncThunk";
 import axiosInstance from "@/domain/shared/axios";
 import {
   ReactionFeedRequestDto,
@@ -10,7 +11,7 @@ import {
 import { toKSTISOString } from "@/domain/shared/function";
 
 // 일기장 불러오기 (무한 스크롤) -----------------------------------------------------
-export const fetchFeedEntries = createAsyncThunk(
+export const fetchFeedEntries = createCustomAsyncThunk(
   "feed/fetchFeedEntries",
   async (params?: number) => {
     const response = await axiosInstance.get(`/diary/public?after=${params}`);
@@ -31,12 +32,12 @@ const addFetchFeedEntries = (builder: ActionReducerMapBuilder<FeedState>) => {
   });
   builder.addCase(fetchFeedEntries.rejected, (state, action) => {
     state.loading = false;
-    state.error = action.error.message ?? null;
+    state.error = action.payload?.message ?? null;
   });
 };
 
 // 일기장 반응 이벤트 -----------------------------------------------------
-export const reactionFeed = createAsyncThunk(
+export const reactionFeed = createCustomAsyncThunk(
   "feed/reactionFeed",
   async (data: ReactionFeedType) => {
     const reactionFeedDto = new ReactionFeedRequestDto(data);
@@ -58,12 +59,12 @@ const addReactionFeed = (builder: ActionReducerMapBuilder<FeedState>) => {
   });
   builder.addCase(reactionFeed.rejected, (state, action) => {
     state.loading = false;
-    state.error = action.error.message ?? null;
+    state.error = action.payload?.message ?? null;
   });
 };
 
 // 일기장 공개 업로드 -----------------------------------------------------
-export const uploadFeed = createAsyncThunk(
+export const uploadFeed = createCustomAsyncThunk(
   "Feed/uploadFeed",
   async (data: UploadFeedType) => {
     const uploadFeedDto = new UploadFeedRequestDto(data);
@@ -85,12 +86,12 @@ const addUploadFeed = (builder: ActionReducerMapBuilder<FeedState>) => {
   });
   builder.addCase(uploadFeed.rejected, (state, action) => {
     state.loading = false;
-    state.error = action.error.message ?? null;
+    state.error = action.payload?.message ?? null;
   });
 };
 
 // 나의 공개 일기 불러오기(무한스크롤)  -----------------------------------------------------
-export const fetchMyFeedEntries = createAsyncThunk(
+export const fetchMyFeedEntries = createCustomAsyncThunk(
   "Feed/fetchMyFeedEntries",
   async (params: number) => {
     const response = await axiosInstance.get(
@@ -113,12 +114,12 @@ const addFetchMyFeedEntries = (builder: ActionReducerMapBuilder<FeedState>) => {
   });
   builder.addCase(fetchMyFeedEntries.rejected, (state, action) => {
     state.loading = false;
-    state.error = action.error.message ?? null;
+    state.error = action.payload?.message ?? null;
   });
 };
 
 // 나의 공개 일기 상세 조회 -----------------------------------------------------
-export const fetchMyFeedDetail = createAsyncThunk(
+export const fetchMyFeedDetail = createCustomAsyncThunk(
   "Feed/fetchMyFeedDetail",
   async (params: string) => {
     const date = toKSTISOString(new Date(params));
@@ -140,7 +141,7 @@ const addFetchMyFeedDetail = (builder: ActionReducerMapBuilder<FeedState>) => {
   });
   builder.addCase(fetchMyFeedDetail.rejected, (state, action) => {
     state.loading = false;
-    state.error = action.error.message ?? null;
+    state.error = action.payload?.message ?? null;
   });
 };
 

--- a/domain/member/components/PreviewUrlLabel.tsx
+++ b/domain/member/components/PreviewUrlLabel.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useDispatch, useSelector } from "react-redux";
+import Image from "next/image";
+import { RootState } from "@/redux";
+import { Button, Label, Spinner } from "flowbite-react";
+import {
+  fetchCharacter,
+  registerCharacter,
+} from "../slices/memberExtraReducers";
+import { useEffect } from "react";
+import { setAlert } from "@/domain/noti/slices/notiSlice";
+import { clearRegister } from "../slices/memberSlice";
+
+const PreviewUrlLabel = () => {
+  const dispatch = useDispatch();
+  const previewUrl = useSelector(
+    (state: RootState) => state.member.characterCreate.createdCharacterUrl
+  );
+  const isCreateCharacter = useSelector(
+    (state: RootState) => state.member.characterCreate.isCreateCharacter
+  );
+  const isRegisterCharacter = useSelector(
+    (state: RootState) => state.member.characterCreate.isRegisterCharacter
+  );
+
+  const handleRegisterCharacter = () => {
+    dispatch<any>(registerCharacter());
+  };
+
+  const handleReload = () => {
+    dispatch<any>(fetchCharacter());
+  };
+
+  useEffect(() => {
+    dispatch<any>(fetchCharacter());
+  }, []);
+
+  useEffect(() => {
+    if (!isRegisterCharacter) return;
+    dispatch(
+      setAlert({
+        title: "알림",
+        message: "캐릭터가 등록되었습니다.",
+        color: "success",
+      })
+    );
+    dispatch(clearRegister());
+  }, [isRegisterCharacter]);
+
+  return (
+    <div className="space-y-4">
+      <Label value="2. 캐릭터 생성 / 등록" />
+      <label
+        onClick={handleReload}
+        className="flex flex-col items-start justify-center w-48 h-48 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer bg-gray-50 dark:hover:bg-gray-800 dark:bg-gray-700 hover:bg-gray-100 dark:border-gray-s0 dark:hover:border-gray-500 dark:hover:bg-gray-600"
+      >
+        {previewUrl ? (
+          <Image
+            width={200}
+            height={200}
+            src={previewUrl}
+            alt={`업로드된 이미지 ${previewUrl}`}
+            sizes="100vw"
+            style={{ width: "100%", height: "100%" }}
+            className="rounded-lg shadow-md object-cover"
+          />
+        ) : (
+          <>
+            <div className="w-full flex flex-col items-center justify-center pt-5 pb-6">
+              <Spinner
+                className={isCreateCharacter ? "" : "hidden"}
+                size="xl"
+              />
+              <br></br>
+              <p className="text-xs text-center">
+                캐릭터 생성에 약 1 ~ 2분<br></br> 정도 걸릴 수 있습니다.
+              </p>
+            </div>
+          </>
+        )}
+      </label>
+      <div className="flex justify-center">
+        <Button
+          className={previewUrl ? "" : "hidden"}
+          onClick={handleRegisterCharacter}
+        >
+          캐릭터 등록
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default PreviewUrlLabel;

--- a/domain/member/components/UploadFileLabel.tsx
+++ b/domain/member/components/UploadFileLabel.tsx
@@ -1,16 +1,16 @@
 "use client";
 
-import { RootState } from "@/redux";
-import { encodeFileToBase64 } from "@/domain/shared/function";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { setSelectedFile } from "../slices/memberSlice";
+import { clearCharacter, setMemberImageFile } from "../slices/memberSlice";
+import Image from "next/image";
+import { RootState } from "@/redux";
+import { Button, Label } from "flowbite-react";
+import { setAlert } from "@/domain/noti/slices/notiSlice";
+import { createCharacter } from "../slices/memberExtraReducers";
 
 const UploadFileLabel: React.FC = () => {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-  const characterImageUrl = useSelector(
-    (state: RootState) => state.member.characterImageUrl
-  );
   const dispatch = useDispatch();
 
   const handleFileChange = async (
@@ -20,10 +20,11 @@ const UploadFileLabel: React.FC = () => {
     if (!file) {
       return;
     }
-    // const base64File = await encodeFileToBase64(file);
     // 파일 객체로 저장함
-    dispatch(setSelectedFile(file));
+    dispatch(setMemberImageFile(file));
+  };
 
+  const handlePreviewImage = (file: File) => {
     // 파일 미리보기
     const reader = new FileReader();
     reader.onloadend = () => {
@@ -33,23 +34,95 @@ const UploadFileLabel: React.FC = () => {
   };
 
   // 캐릭터 이미지 URL이 변경되면 미리보기 URL 변경
+  const file = useSelector(
+    (state: RootState) => state.member.characterCreate.memberImageFile
+  );
   useEffect(() => {
-    if (characterImageUrl) {
-      setPreviewUrl(characterImageUrl);
+    if (file) {
+      handlePreviewImage(file);
     }
-  }, [characterImageUrl]);
+  }, [file]);
+
+  const memberImageFile = useSelector(
+    (state: RootState) => state.member.characterCreate.memberImageFile
+  );
+  const isDuplicateRequest = useSelector(
+    (state: RootState) => state.member.characterCreate.isCreateCharacter
+  );
+
+  const pass5minute = () => {
+    const lastCharacter = localStorage.getItem("lastCharacter");
+    if (lastCharacter) {
+      const lastCreateTime = new Date(lastCharacter);
+      const currentTime = new Date();
+      const timeDiff = currentTime.getTime() - lastCreateTime.getTime();
+      const minutesDiff = Math.floor(timeDiff / (1000 * 60));
+
+      if (minutesDiff < 5) {
+        dispatch<any>(
+          setAlert({
+            title: "알림",
+            message: `${5 - minutesDiff}분 후에 다시 시도해주세요.`,
+            color: "warning",
+          })
+        );
+        return false;
+      }
+    }
+    localStorage.setItem("lastCharacter", new Date().toISOString());
+    return true;
+  };
+
+  const handleCreateCharacter = async () => {
+    if (!memberImageFile) {
+      dispatch<any>(
+        setAlert({
+          title: "알림",
+          message: "이미지를 업로드해주세요.",
+          color: "info",
+        })
+      );
+      return;
+    }
+    if (isDuplicateRequest) {
+      dispatch<any>(
+        setAlert({
+          title: "알림",
+          message: "캐릭터를 중복으로 생성할 수 없습니다.",
+          color: "warning",
+        })
+      );
+      return;
+    }
+
+    if (!pass5minute()) {
+      return;
+    }
+
+    dispatch<any>(
+      createCharacter({
+        image: memberImageFile,
+      })
+    );
+    dispatch(clearCharacter());
+  };
 
   return (
-    <div>
+    <div className="space-y-4">
+      <Label value="1. 이미지 파일 선택" />
       <label
         htmlFor="dropzone-file"
-        className="flex flex-col items-start justify-center w-64 h-64 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer bg-gray-50 dark:hover:bg-gray-800 dark:bg-gray-700 hover:bg-gray-100 dark:border-gray-600 dark:hover:border-gray-500 dark:hover:bg-gray-600"
+        className="flex flex-col items-start justify-center w-48 h-48 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer bg-gray-50 dark:hover:bg-gray-800 dark:bg-gray-700 hover:bg-gray-100 dark:border-gray-s0 dark:hover:border-gray-500 dark:hover:bg-gray-600"
       >
         {previewUrl ? (
-          <img
+          <Image
+            width={200}
+            height={200}
             src={previewUrl}
-            alt="업로드된 이미지"
-            className="w-full h-full object-cover rounded-lg"
+            alt={`업로드된 이미지 ${previewUrl}`}
+            sizes="100vw"
+            style={{ width: "100%", height: "100%" }}
+            className="rounded-lg shadow-md object-cover"
           />
         ) : (
           <div className="w-full flex flex-col items-center justify-center pt-5 pb-6">
@@ -72,7 +145,7 @@ const UploadFileLabel: React.FC = () => {
               className="
             text-xs text-gray-500 dark:text-gray-400"
             >
-              SVG, PNG, JPG (최대 800x400px)
+              PNG, JPG, JPEG, WEBP 권장
             </p>
           </div>
         )}
@@ -84,6 +157,14 @@ const UploadFileLabel: React.FC = () => {
           accept="image/*"
         />
       </label>
+      <div className="flex justify-center">
+        <Button
+          className={memberImageFile ? "" : "hidden"}
+          onClick={handleCreateCharacter}
+        >
+          캐릭터 생성하기
+        </Button>
+      </div>
     </div>
   );
 };

--- a/domain/member/components/UploadFileLabel.tsx
+++ b/domain/member/components/UploadFileLabel.tsx
@@ -20,8 +20,9 @@ const UploadFileLabel: React.FC = () => {
     if (!file) {
       return;
     }
-    const base64File = await encodeFileToBase64(file);
-    dispatch(setSelectedFile(base64File as string));
+    // const base64File = await encodeFileToBase64(file);
+    // 파일 객체로 저장함
+    dispatch(setSelectedFile(file));
 
     // 파일 미리보기
     const reader = new FileReader();

--- a/domain/member/components/index.ts
+++ b/domain/member/components/index.ts
@@ -1,3 +1,5 @@
 import UserAvatarWithLabel from "./UserAvatarWithLabel";
 import UploadFileLabel from "./UploadFileLabel";
-export { UploadFileLabel, UserAvatarWithLabel };
+import PreviewUrlLabel from "./PreviewUrlLabel";
+
+export { UploadFileLabel, UserAvatarWithLabel, PreviewUrlLabel };

--- a/domain/member/dto/request/createCharacterDto.ts
+++ b/domain/member/dto/request/createCharacterDto.ts
@@ -1,27 +1,14 @@
-// 캐릭터 생성 타입 정의 -----------------------------------------------------
+// 멀티파트 이미지 전송을 위한 타입 정의
 export type CreateCharacterType = {
-  image: string;
+  image: File; // 멀티파트 이미지 타입으로 File 사용
 };
 
-// 캐릭터 생성 요청 DTO 클래스 -----------------------------------------------------
+// DTO 클래스 정의
 export class CreateCharacterRequestDto implements CreateCharacterType {
-  public image: string;
+  public image: File;
 
-  // 네임드 파라미터 방식의 생성자
   constructor({ image }: CreateCharacterType) {
-    // if (!this.isValidBase64Image(image)) {
-    //   throw new Error("허용하지 않는 이미지 포맷입니다.");
-    // }
-
-    this.image = image.trim();
-  }
-
-  // Base64 이미지 형식 검증 메서드
-  private isValidBase64Image(image: string): boolean {
-    // 이미지의 MIME 타입이 포함된 Base64 형식의 시작 부분 예시: data:image/png;base64, 또는 data:image/jpeg;base64,
-    const base64Regex =
-      /^data:image\/[a-zA-Z0-9+.-]+;base64,[A-Za-z0-9+/]+={0,2}$/;
-    return base64Regex.test(image);
+    this.image = image;
   }
 
   // 객체 형태로 반환
@@ -29,5 +16,12 @@ export class CreateCharacterRequestDto implements CreateCharacterType {
     return {
       image: this.image,
     };
+  }
+
+  // FormData로 변환하는 메서드 추가
+  toFormData(): FormData {
+    const formData = new FormData();
+    formData.append("uploadImage", this.image); // 'image' 필드에 파일 추가
+    return formData;
   }
 }

--- a/domain/member/dto/request/createCharacterDto.ts
+++ b/domain/member/dto/request/createCharacterDto.ts
@@ -9,9 +9,9 @@ export class CreateCharacterRequestDto implements CreateCharacterType {
 
   // 네임드 파라미터 방식의 생성자
   constructor({ image }: CreateCharacterType) {
-    if (!this.isValidBase64Image(image)) {
-      throw new Error("허용하지 않는 이미지 포맷입니다.");
-    }
+    // if (!this.isValidBase64Image(image)) {
+    //   throw new Error("허용하지 않는 이미지 포맷입니다.");
+    // }
 
     this.image = image.trim();
   }

--- a/domain/member/mocks/member.ts
+++ b/domain/member/mocks/member.ts
@@ -3,7 +3,7 @@ import { HttpResponse, http } from "msw";
 const url = process.env.NEXT_PUBLIC_API_URL;
 export const memberMockups = [
   // 회원 정보
-  http.get(url + "/member/detail", () => {
+  http.get(url + "/member/profile", () => {
     return HttpResponse.json({
       nickname: "todak",
       email: "ktb@gmail.com",
@@ -11,30 +11,22 @@ export const memberMockups = [
     });
   }),
 
-  // 회원 정보 축약
-  // http.get(url + "/member/summary", () => {
-  //   return HttpResponse.json({
-  //     nickname: "todak",
-  //     characterImageUrl: "/minion2.png",
-  //   });
-  // }),
-
   // 캐릭터 불러오기
-  http.get(url + "/member/image", () => {
+  http.get(url + "member/character", () => {
     return HttpResponse.json({
       characterImageUrl: "/minion3.png",
     });
   }),
 
   // 캐릭터 생성
-  http.post(url + "/member/image", () => {
+  http.post(url + "/member/character", () => {
     return HttpResponse.json({
       characterImageUrl: "/minion4.png",
     });
   }),
 
   // 캐릭터 등록
-  http.post(url + "/member/image/register", () => {
+  http.post(url + "member/character/register", () => {
     return new HttpResponse(null, { status: 204 });
   }),
 

--- a/domain/member/mocks/member.ts
+++ b/domain/member/mocks/member.ts
@@ -12,21 +12,21 @@ export const memberMockups = [
   }),
 
   // 캐릭터 불러오기
-  http.get(url + "member/character", () => {
+  http.get(url + "/member/character", () => {
     return HttpResponse.json({
       characterImageUrl: "/minion3.png",
     });
   }),
 
   // 캐릭터 생성
-  http.post(url + "/member/character", () => {
+  http.post(url + "/member/character", async () => {
     return HttpResponse.json({
       characterImageUrl: "/minion4.png",
     });
   }),
 
   // 캐릭터 등록
-  http.post(url + "member/character/register", () => {
+  http.post(url + "/member/character/register", () => {
     return new HttpResponse(null, { status: 204 });
   }),
 

--- a/domain/member/slices/memberExtraReducers.ts
+++ b/domain/member/slices/memberExtraReducers.ts
@@ -1,13 +1,12 @@
 import { ActionReducerMapBuilder, createAsyncThunk } from "@reduxjs/toolkit";
 import { MemberState } from "./memberSlice";
 import axiosInstance from "@/domain/shared/axios";
-import {
-  ChangeNicknameType,
-  CreateCharacterType,
-} from "../types/memberRequestType";
+
 import {
   ChangeNicknameRequestDto,
+  ChangeNicknameType,
   CreateCharacterRequestDto,
+  CreateCharacterType,
 } from "../dto/request";
 
 // 회원 정보 -----------------------------------------------------
@@ -66,7 +65,12 @@ export const createCharacter = createAsyncThunk(
     const createCharacterDto = new CreateCharacterRequestDto(data);
     const response = await axiosInstance.post(
       "/member/character",
-      createCharacterDto.toObject()
+      createCharacterDto.toFormData(),
+      {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+      }
     );
     return response.data;
   }

--- a/domain/member/slices/memberExtraReducers.ts
+++ b/domain/member/slices/memberExtraReducers.ts
@@ -25,9 +25,9 @@ const addFetchMemberInfo = (builder: ActionReducerMapBuilder<MemberState>) => {
     state.error = null;
   });
   builder.addCase(fetchMemberInfo.fulfilled, (state, action) => {
-    state.email = action.payload.email;
-    state.nickname = action.payload.nickname;
-    state.characterImageUrl = action.payload.characterImageUrl;
+    state.profile.email = action.payload.email;
+    state.profile.nickname = action.payload.nickname;
+    state.profile.characterImageUrl = action.payload.characterImageUrl;
     state.loading = false;
   });
   builder.addCase(fetchMemberInfo.rejected, (state, action) => {
@@ -40,7 +40,7 @@ const addFetchMemberInfo = (builder: ActionReducerMapBuilder<MemberState>) => {
 export const fetchCharacter = createCustomAsyncThunk(
   "namespace/fetchCharacter",
   async () => {
-    const response = await axiosInstance.get("member/character");
+    const response = await axiosInstance.get("/member/character");
     return response.data;
   }
 );
@@ -51,6 +51,8 @@ const addFetchCharacter = (builder: ActionReducerMapBuilder<MemberState>) => {
     state.error = null;
   });
   builder.addCase(fetchCharacter.fulfilled, (state, action) => {
+    state.characterCreate.createdCharacterUrl =
+      action.payload.characterImageUrl;
     state.loading = false;
   });
   builder.addCase(fetchCharacter.rejected, (state, action) => {
@@ -83,8 +85,7 @@ const addCreateCharacter = (builder: ActionReducerMapBuilder<MemberState>) => {
     state.error = null;
   });
   builder.addCase(createCharacter.fulfilled, (state, action) => {
-    state.characterImageUrl = action.payload.characterImageUrl;
-    state.isCreateCharacter = true; // 캐릭터 등록에 의존성 걸려있음
+    state.characterCreate.isCreateCharacter = true; // 캐릭터 등록에 의존성 걸려있음
     state.loading = false;
   });
   builder.addCase(createCharacter.rejected, (state, action) => {
@@ -97,7 +98,7 @@ const addCreateCharacter = (builder: ActionReducerMapBuilder<MemberState>) => {
 export const registerCharacter = createCustomAsyncThunk(
   "member/registerCharacter",
   async () => {
-    const response = await axiosInstance.post("member/character/register");
+    const response = await axiosInstance.post("/member/character/register");
     return response.data;
   }
 );
@@ -111,7 +112,7 @@ const addRegisterCharacter = (
   });
   builder.addCase(registerCharacter.fulfilled, (state, action) => {
     localStorage.setItem("accessToken", action.payload.accessToken);
-    state.isRegisterCharacter = true;
+    state.characterCreate.isRegisterCharacter = true;
     state.loading = false;
   });
   builder.addCase(registerCharacter.rejected, (state, action) => {

--- a/domain/member/slices/memberExtraReducers.ts
+++ b/domain/member/slices/memberExtraReducers.ts
@@ -1,6 +1,7 @@
-import { ActionReducerMapBuilder, createAsyncThunk } from "@reduxjs/toolkit";
+import { ActionReducerMapBuilder } from "@reduxjs/toolkit";
 import { MemberState } from "./memberSlice";
 import axiosInstance from "@/domain/shared/axios";
+import createCustomAsyncThunk from "@/redux/createCustomAsyncThunk";
 
 import {
   ChangeNicknameRequestDto,
@@ -10,7 +11,7 @@ import {
 } from "../dto/request";
 
 // 회원 정보 -----------------------------------------------------
-export const fetchMemberInfo = createAsyncThunk(
+export const fetchMemberInfo = createCustomAsyncThunk(
   "member/fetchMemberInfo",
   async () => {
     const response = await axiosInstance.get("/member/profile");
@@ -31,15 +32,15 @@ const addFetchMemberInfo = (builder: ActionReducerMapBuilder<MemberState>) => {
   });
   builder.addCase(fetchMemberInfo.rejected, (state, action) => {
     state.loading = false;
-    state.error = action.error.message ?? null;
+    state.error = action.payload?.message ?? null;
   });
 };
 
 // 캐릭터 불러오기 -----------------------------------------------------
-export const fetchCharacter = createAsyncThunk(
+export const fetchCharacter = createCustomAsyncThunk(
   "namespace/fetchCharacter",
   async () => {
-    const response = await axiosInstance.get("/member/image");
+    const response = await axiosInstance.get("member/character");
     return response.data;
   }
 );
@@ -54,12 +55,12 @@ const addFetchCharacter = (builder: ActionReducerMapBuilder<MemberState>) => {
   });
   builder.addCase(fetchCharacter.rejected, (state, action) => {
     state.loading = false;
-    state.error = action.error.message ?? null;
+    state.error = action.payload?.message ?? null;
   });
 };
 
 // 캐릭터 생성 -----------------------------------------------------
-export const createCharacter = createAsyncThunk(
+export const createCharacter = createCustomAsyncThunk(
   "member/createCharacter",
   async (data: CreateCharacterType) => {
     const createCharacterDto = new CreateCharacterRequestDto(data);
@@ -88,15 +89,15 @@ const addCreateCharacter = (builder: ActionReducerMapBuilder<MemberState>) => {
   });
   builder.addCase(createCharacter.rejected, (state, action) => {
     state.loading = false;
-    state.error = action.error.message ?? null;
+    state.error = action.payload?.message ?? null;
   });
 };
 
 // 캐릭터 등록 -----------------------------------------------------
-export const registerCharacter = createAsyncThunk(
+export const registerCharacter = createCustomAsyncThunk(
   "member/registerCharacter",
   async () => {
-    const response = await axiosInstance.post("/member/character/register");
+    const response = await axiosInstance.post("member/character/register");
     return response.data;
   }
 );
@@ -115,12 +116,12 @@ const addRegisterCharacter = (
   });
   builder.addCase(registerCharacter.rejected, (state, action) => {
     state.loading = false;
-    state.error = action.error.message ?? null;
+    state.error = action.payload?.message ?? null;
   });
 };
 
 // 닉네임 변경 -----------------------------------------------------
-export const changeNickname = createAsyncThunk(
+export const changeNickname = createCustomAsyncThunk(
   "member/changeNickname",
   async (data: ChangeNicknameType) => {
     const changeNicknameDto = new ChangeNicknameRequestDto(data);
@@ -142,7 +143,7 @@ const addChangeNickname = (builder: ActionReducerMapBuilder<MemberState>) => {
   });
   builder.addCase(changeNickname.rejected, (state, action) => {
     state.loading = false;
-    state.error = action.error.message ?? null;
+    state.error = action.payload?.message ?? null;
   });
 };
 

--- a/domain/member/slices/memberExtraReducers.ts
+++ b/domain/member/slices/memberExtraReducers.ts
@@ -14,7 +14,7 @@ import {
 export const fetchMemberInfo = createAsyncThunk(
   "member/fetchMemberInfo",
   async () => {
-    const response = await axiosInstance.get("/member/detail");
+    const response = await axiosInstance.get("/member/profile");
     return response.data;
   }
 );
@@ -65,7 +65,7 @@ export const createCharacter = createAsyncThunk(
   async (data: CreateCharacterType) => {
     const createCharacterDto = new CreateCharacterRequestDto(data);
     const response = await axiosInstance.post(
-      "/member/image",
+      "/member/character",
       createCharacterDto.toObject()
     );
     return response.data;
@@ -92,7 +92,7 @@ const addCreateCharacter = (builder: ActionReducerMapBuilder<MemberState>) => {
 export const registerCharacter = createAsyncThunk(
   "member/registerCharacter",
   async () => {
-    const response = await axiosInstance.post("/member/image/register");
+    const response = await axiosInstance.post("/member/character/register");
     return response.data;
   }
 );
@@ -105,6 +105,7 @@ const addRegisterCharacter = (
     state.error = null;
   });
   builder.addCase(registerCharacter.fulfilled, (state, action) => {
+    localStorage.setItem("accessToken", action.payload.accessToken);
     state.isRegisterCharacter = true;
     state.loading = false;
   });

--- a/domain/member/slices/memberSlice.ts
+++ b/domain/member/slices/memberSlice.ts
@@ -4,10 +4,11 @@ import { addMemberExtraReducers } from "./memberExtraReducers";
 export interface MemberState {
   nickname: string;
   email: string;
+  memberImage: File;
   characterImageUrl: string;
   isCreateCharacter: boolean;
   isRegisterCharacter: boolean;
-  selectedFile: string;
+  selectedFile: File;
   loading: boolean;
   error: string | null;
 }
@@ -15,10 +16,11 @@ export interface MemberState {
 const initialState: MemberState = {
   nickname: "",
   email: "",
+  memberImage: new File([], ""),
   characterImageUrl: "",
   isCreateCharacter: false,
   isRegisterCharacter: false,
-  selectedFile: "",
+  selectedFile: new File([], ""),
   loading: false,
   error: null,
 };
@@ -30,17 +32,20 @@ const memberSlice = createSlice({
     setNickname: (state: MemberState, action: PayloadAction<string>) => {
       state.nickname = action.payload;
     },
-    setSelectedFile: (state: MemberState, action: PayloadAction<string>) => {
+    setSelectedFile: (state: MemberState, action: PayloadAction<File>) => {
       state.selectedFile = action.payload;
     },
     clearCharacter: (state: MemberState) => {
       state.isCreateCharacter = false;
       state.isRegisterCharacter = false;
     },
+    setMemberImage: (state: MemberState, action: PayloadAction<File>) => {
+      state.memberImage = action.payload;
+    },
   },
   extraReducers: (builder: any) => addMemberExtraReducers(builder),
 });
 
-export const { setNickname, setSelectedFile, clearCharacter } =
+export const { setNickname, setSelectedFile, clearCharacter, setMemberImage } =
   memberSlice.actions;
 export default memberSlice.reducer;

--- a/domain/member/slices/memberSlice.ts
+++ b/domain/member/slices/memberSlice.ts
@@ -2,25 +2,33 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { addMemberExtraReducers } from "./memberExtraReducers";
 
 export interface MemberState {
-  nickname: string;
-  email: string;
-  memberImage: File;
-  characterImageUrl: string;
-  isCreateCharacter: boolean;
-  isRegisterCharacter: boolean;
-  selectedFile: File;
+  profile: {
+    nickname: string;
+    email: string;
+    characterImageUrl: string;
+  };
+  characterCreate: {
+    memberImageFile: File | null; // 미리보기
+    createdCharacterUrl: string; // 미리보기
+    isCreateCharacter: boolean; // 생성되었는가
+    isRegisterCharacter: boolean; // 등록했는가
+  };
   loading: boolean;
   error: string | null;
 }
 
 const initialState: MemberState = {
-  nickname: "",
-  email: "",
-  memberImage: new File([], ""),
-  characterImageUrl: "",
-  isCreateCharacter: false,
-  isRegisterCharacter: false,
-  selectedFile: new File([], ""),
+  profile: {
+    nickname: "",
+    email: "",
+    characterImageUrl: "",
+  },
+  characterCreate: {
+    memberImageFile: null,
+    createdCharacterUrl: "",
+    isCreateCharacter: false,
+    isRegisterCharacter: false,
+  },
   loading: false,
   error: null,
 };
@@ -30,22 +38,28 @@ const memberSlice = createSlice({
   initialState,
   reducers: {
     setNickname: (state: MemberState, action: PayloadAction<string>) => {
-      state.nickname = action.payload;
-    },
-    setSelectedFile: (state: MemberState, action: PayloadAction<File>) => {
-      state.selectedFile = action.payload;
+      state.profile.nickname = action.payload;
     },
     clearCharacter: (state: MemberState) => {
-      state.isCreateCharacter = false;
-      state.isRegisterCharacter = false;
+      state.characterCreate.createdCharacterUrl = "";
+      state.characterCreate.isCreateCharacter = false;
+      state.characterCreate.isRegisterCharacter = false;
     },
-    setMemberImage: (state: MemberState, action: PayloadAction<File>) => {
-      state.memberImage = action.payload;
+    setMemberImageFile: (state: MemberState, action: PayloadAction<File>) => {
+      state.characterCreate.memberImageFile = action.payload;
+    },
+    clearRegister: (state: MemberState) => {
+      state.characterCreate.isCreateCharacter = false;
+      state.characterCreate.isRegisterCharacter = false;
     },
   },
   extraReducers: (builder: any) => addMemberExtraReducers(builder),
 });
 
-export const { setNickname, setSelectedFile, clearCharacter, setMemberImage } =
-  memberSlice.actions;
+export const {
+  setNickname,
+  setMemberImageFile,
+  clearCharacter,
+  clearRegister,
+} = memberSlice.actions;
 export default memberSlice.reducer;

--- a/domain/member/types/memberRequestType.ts
+++ b/domain/member/types/memberRequestType.ts
@@ -1,9 +1,0 @@
-// 캐릭터 생성 -----------------------------------------------------
-export type CreateCharacterType = {
-  image: string;
-};
-
-// 닉네임 변경 -----------------------------------------------------
-export type ChangeNicknameType = {
-  nickname: string;
-};

--- a/domain/shared/axios/axiosInstance.ts
+++ b/domain/shared/axios/axiosInstance.ts
@@ -1,4 +1,11 @@
-import axios, { AxiosError } from "axios";
+import { reissueToken } from "@/domain/auth/slices/login/loginExtraReducers";
+import axios from "axios";
+
+// 순환참조 제거
+let storeRef: any;
+export const setAxiosInnerStore = (store: any) => {
+  storeRef = store;
+};
 
 // Axios 인스턴스 생성
 const axiosInstance = axios.create({
@@ -29,12 +36,22 @@ axiosInstance.interceptors.request.use(
   }
 );
 
+// 응답 인터셉터 설정
 axiosInstance.interceptors.response.use(
-  (response) => {
-    // 2xx 범위에 있는 상태 코드는 이 함수를 트리거 합니다.
-    return response;
-  },
+  (response) => response,
   async (error) => {
+    const { response, config } = error;
+    if (response && response.status === 401 && !config._retry) {
+      config._retry = true;
+      try {
+        storeRef?.dispatch(reissueToken());
+        // 토큰 재발급 후 원래 요청 재시도
+        return axiosInstance(config);
+      } catch (err) {
+        // 재발급 실패 시 로그인 페이지로 리디렉션 등 처리
+        return Promise.reject(err);
+      }
+    }
     return Promise.reject(error);
   }
 );

--- a/domain/shared/axios/axiosInstance.ts
+++ b/domain/shared/axios/axiosInstance.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 
 // Axios 인스턴스 생성
 const axiosInstance = axios.create({

--- a/domain/shared/components/CarouselAudioEmoji.tsx
+++ b/domain/shared/components/CarouselAudioEmoji.tsx
@@ -26,7 +26,7 @@ const CarouselAudioEmoji: React.FC<CarouselAudioEmojiProps> = ({
 }) => {
   return (
     <div className="w-full relative">
-      <Carousel slide={false} draggable={true}>
+      <Carousel slide={true} draggable={true}>
         {webtoonImageUrls?.map((imageUrl, index) => (
           <div
             key={index}

--- a/domain/shared/components/CarouselAudioEmoji.tsx
+++ b/domain/shared/components/CarouselAudioEmoji.tsx
@@ -26,7 +26,7 @@ const CarouselAudioEmoji: React.FC<CarouselAudioEmojiProps> = ({
 }) => {
   return (
     <div className="w-full relative">
-      <Carousel slide={true} draggable={true}>
+      <Carousel slide={false} draggable={true}>
         {webtoonImageUrls?.map((imageUrl, index) => (
           <div
             key={index}

--- a/domain/shared/components/layout/BottomNavigation.tsx
+++ b/domain/shared/components/layout/BottomNavigation.tsx
@@ -22,7 +22,7 @@ const BottomNavigation: React.FC = () => {
         >
           <HomeSVG />
           <span className="text-sm text-gray-500 dark:text-gray-400 group-hover:text-cyan-600 dark:group-hover:text-cyan-500">
-            Home
+            피드
           </span>
         </button>
         <button
@@ -32,7 +32,7 @@ const BottomNavigation: React.FC = () => {
         >
           <PencilSVG />
           <span className="text-sm text-gray-500 dark:text-gray-400 group-hover:text-cyan-600 dark:group-hover:text-cyan-500">
-            Diary
+            내 일기
           </span>
         </button>
         <button
@@ -42,7 +42,7 @@ const BottomNavigation: React.FC = () => {
         >
           <UserSVG />
           <span className="text-sm text-gray-500 dark:text-gray-400 group-hover:text-cyan-600 dark:group-hover:text-cyan-500">
-            My
+            내 정보
           </span>
         </button>
       </div>

--- a/domain/shared/components/layout/HeaderNavigation.tsx
+++ b/domain/shared/components/layout/HeaderNavigation.tsx
@@ -20,7 +20,7 @@ const HeaderNavigation: React.FC = () => {
         >
           <img src="/todak-logo.svg" className="h-6 ml-2" alt="Flowbite Logo" />
           <h1 className="self-center text-2xl font-gamja whitespace-nowrap dark:text-white">
-            TODAK
+            토닥토닥
           </h1>
         </Link>
       </div>

--- a/domain/shared/components/layout/Logo.tsx
+++ b/domain/shared/components/layout/Logo.tsx
@@ -5,9 +5,8 @@ import React, { useEffect, useState } from "react";
 
 const Logo: React.FC = () => {
   const [index, setIndex] = useState(0);
-  const [titleIndex, setTitleIndex] = useState(0);
 
-  const title = ["TODAK TODAK", "토닥토닥"];
+  const title = "토닥토닥";
 
   const keyword = [
     "일상을 나누는 일기, 마음을 따뜻하게 감싸다",
@@ -19,7 +18,6 @@ const Logo: React.FC = () => {
   useEffect(() => {
     setTimeout(() => {
       setIndex((index + 1) % keyword.length);
-      setTitleIndex((titleIndex + 1) % title.length);
     }, 10000);
   }, [index]);
 
@@ -29,7 +27,7 @@ const Logo: React.FC = () => {
         <h1 id="todak-title" className="text-3xl font-bold text-cyan-800">
           <div className="flex gap-2">
             <img src="/todak-logo.svg" />
-            <p className="font-gamja text-6xl">{title[titleIndex]}</p>
+            <p className="font-gamja text-6xl">{title}</p>
           </div>
         </h1>
       </Label>

--- a/domain/shared/components/layout/MyAlert.tsx
+++ b/domain/shared/components/layout/MyAlert.tsx
@@ -39,7 +39,7 @@ const MyAlert: React.FC = () => {
   return (
     <Alert
       color={alert.color}
-      className="flex fixed top-4 left-1/2 transform -translate-x-1/2 w-96 z-50"
+      className="flex fixed top-4 left-1/2 transform -translate-x-1/2 w-96 z-[9999]"
       onDismiss={() => dispatch(clearAlert())}
       withBorderAccent
       icon={HiInformationCircle}

--- a/domain/shared/components/layout/MyAlert.tsx
+++ b/domain/shared/components/layout/MyAlert.tsx
@@ -34,7 +34,7 @@ const MyAlert: React.FC = () => {
   }, [alert, dispatch]);
 
   // alert가 없거나 메시지가 비어 있을 때는 렌더링하지 않음
-  if (!alert || alert.message === "") return null;
+  if (!alert || alert.message === "" || alert.message === "none") return null;
 
   return (
     <Alert

--- a/domain/shared/function/toKSTISOString.ts
+++ b/domain/shared/function/toKSTISOString.ts
@@ -6,7 +6,7 @@ const toKSTISOString = (date: Date): string => {
   const kstDate = new Date(date.getTime() + KST_OFFSET);
 
   // KST 시간에 대한 ISO 포맷 문자열 반환 (초 마지막의 'Z'를 제거하여 로컬 시간처럼 보이게 함)
-  return kstDate.toISOString().replace("Z", "+09:00");
+  return kstDate.toISOString().replace("Z", "");
 };
 
 export default toKSTISOString;

--- a/domain/shared/hooks/index.ts
+++ b/domain/shared/hooks/index.ts
@@ -1,6 +1,6 @@
 import useHideOnScroll from "./useHideOnScroll";
 import useMocking from "./useMocking";
-import { useEmptyTokenRedirect, useReissueToken } from "./useAuth";
+import { useEmptyTokenRedirect } from "./useAuth";
 import useSaveTextLocalStorage from "./useSaveTextLocalStorage";
 
 export {
@@ -8,5 +8,4 @@ export {
   useMocking,
   useSaveTextLocalStorage,
   useEmptyTokenRedirect,
-  useReissueToken,
 };

--- a/domain/shared/hooks/index.ts
+++ b/domain/shared/hooks/index.ts
@@ -2,10 +2,12 @@ import useHideOnScroll from "./useHideOnScroll";
 import useMocking from "./useMocking";
 import { useEmptyTokenRedirect } from "./useAuth";
 import useSaveTextLocalStorage from "./useSaveTextLocalStorage";
+import useLoginChecker from "./useLoginChecker";
 
 export {
   useHideOnScroll,
   useMocking,
   useSaveTextLocalStorage,
   useEmptyTokenRedirect,
+  useLoginChecker,
 };

--- a/domain/shared/hooks/useAuth.ts
+++ b/domain/shared/hooks/useAuth.ts
@@ -4,7 +4,6 @@ import { useDispatch } from "react-redux";
 import path from "../routes";
 import { AlertType } from "@/domain/noti/types";
 import { setAlert } from "@/domain/noti/slices/notiSlice";
-import { reissueToken } from "@/domain/auth/slices/login/loginExtraReducers";
 
 export const useEmptyTokenRedirect = () => {
   // 서버사이드에서는 localStorage에 접근할 수 없으므로 반환
@@ -24,19 +23,19 @@ export const useEmptyTokenRedirect = () => {
       dispatch(setAlert(data));
       router.push(path.LOGIN);
     }
-  }, [token, dispatch]);
+  }, [token]);
 };
 
-export const useReissueToken = () => {
-  const dispatch = useDispatch();
-  // 서버사이드에서는 localStorage에 접근할 수 없으므로 반환
-  if (typeof window === "undefined") {
-    return;
-  }
-  useEffect(() => {
-    const token = localStorage.getItem("accessToken");
-    if (!token) {
-      dispatch<any>(reissueToken());
-    }
-  }, []);
-};
+// export const useReissueToken = () => {
+//   const dispatch = useDispatch();
+//   // 서버사이드에서는 localStorage에 접근할 수 없으므로 반환
+//   if (typeof window === "undefined") {
+//     return;
+//   }
+//   useEffect(() => {
+//     const token = localStorage.getItem("accessToken");
+//     if (!token) {
+//       dispatch<any>(reissueToken());
+//     }
+//   }, []);
+// };

--- a/domain/shared/hooks/useLoginChecker.ts
+++ b/domain/shared/hooks/useLoginChecker.ts
@@ -1,0 +1,30 @@
+import { setAlert } from "@/domain/noti/slices/notiSlice";
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+
+const useLoginChecker = () => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const lastLogin = localStorage.getItem("lastLogin");
+    const today = new Date().toDateString();
+
+    const accessToken = localStorage.getItem("accessToken");
+    if (!accessToken) {
+      return;
+    }
+
+    if (lastLogin !== today) {
+      localStorage.setItem("lastLogin", today);
+      dispatch(
+        setAlert({
+          title: "알림",
+          message: `로그인 일시: ${new Date().toLocaleString()}`,
+          color: "success",
+        })
+      );
+    }
+  }, []);
+};
+
+export default useLoginChecker;

--- a/domain/shared/hooks/useMocking.tsx
+++ b/domain/shared/hooks/useMocking.tsx
@@ -1,14 +1,10 @@
-"use client";
-
+import initMocks from "@/mocks";
 import { useEffect } from "react";
 
 const useMocking = () => {
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_API_MOCKING === "enabled") {
-      (async () => {
-        const { initMocks } = await import("@/mocks");
-        await initMocks(); // initMocks를 비동기로 호출하여 초기화 완료
-      })();
+      initMocks();
     }
   }, []);
 };

--- a/mocks/index.ts
+++ b/mocks/index.ts
@@ -12,4 +12,4 @@ const initMocks = async () => {
   }
 };
 
-export { initMocks }; // default export 대신 named export로 수정
+export default initMocks; // default export 대신 named export로 수정

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,7 +2,7 @@
 
 const nextConfig = {
   reactStrictMode: false,
-  // output: "export", // 정적 내보내기 설정 추가
+  output: "export", // 정적 내보내기 설정 추가
 
   // 보안 설정
   images: {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,10 +2,11 @@
 
 const nextConfig = {
   reactStrictMode: false,
-  // output: "export", // 정적 내보내기 설정 추가
+  output: "export", // 정적 내보내기 설정 추가
 
   webpack: (config) => {
     config.resolve.alias["_http_common"] = false;
+    config.cache = false;
     return config;
   },
 };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,8 +2,12 @@
 
 const nextConfig = {
   reactStrictMode: false,
-  output: "export", // 정적 내보내기 설정 추가
+  // output: "export", // 정적 내보내기 설정 추가
 
+  // 보안 설정
+  images: {
+    domains: ["kakaotech19-todak.s3.ap-northeast-2.amazonaws.com"],
+  },
   webpack: (config) => {
     config.resolve.alias["_http_common"] = false;
     config.cache = false;

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80 reuseport;
+    listen [::]:80 reuseport;
+    server_name localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html;
+        # try_files $uri /index.html;
+        try_files $uri $uri.html $uri/ /index.html;
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       next:
         specifier: 14.2.13
         version: 14.2.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      pnpm:
+        specifier: ^9.12.3
+        version: 9.12.3
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1807,6 +1810,11 @@ packages:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
     engines: {node: '>=10.4.0'}
 
+  pnpm@9.12.3:
+    resolution: {integrity: sha512-zOD53pxafJW++UQWnMXf6HQav7FFB4wNUIuGgFaEiofIHmJiRstglny9f9KabAYu9z/4QNlrPIbECsks9KgT7g==}
+    engines: {node: '>=18.12'}
+    hasBin: true
+
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
     engines: {node: '>= 0.4'}
@@ -3438,7 +3446,7 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -3451,7 +3459,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -3473,7 +3481,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -4344,6 +4352,8 @@ snapshots:
       '@xmldom/xmldom': 0.8.10
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
+
+  pnpm@9.12.3: {}
 
   possible-typed-array-names@1.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3412,8 +3412,8 @@ snapshots:
       '@typescript-eslint/parser': 8.13.0(eslint@8.57.1)(typescript@5.6.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.2(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -3432,37 +3432,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.13.0(eslint@8.57.1)(typescript@5.6.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -3473,7 +3473,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       next:
         specifier: 14.2.13
         version: 14.2.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      pnpm:
-        specifier: ^9.12.3
-        version: 9.12.3
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1810,11 +1807,6 @@ packages:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
     engines: {node: '>=10.4.0'}
 
-  pnpm@9.12.3:
-    resolution: {integrity: sha512-zOD53pxafJW++UQWnMXf6HQav7FFB4wNUIuGgFaEiofIHmJiRstglny9f9KabAYu9z/4QNlrPIbECsks9KgT7g==}
-    engines: {node: '>=18.12'}
-    hasBin: true
-
   possible-typed-array-names@1.0.0:
     resolution: {integrity: sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==}
     engines: {node: '>= 0.4'}
@@ -3420,8 +3412,8 @@ snapshots:
       '@typescript-eslint/parser': 8.13.0(eslint@8.57.1)(typescript@5.6.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.2(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -3440,37 +3432,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.13.0(eslint@8.57.1)(typescript@5.6.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -3481,7 +3473,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.13.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -4352,8 +4344,6 @@ snapshots:
       '@xmldom/xmldom': 0.8.10
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
-
-  pnpm@9.12.3: {}
 
   possible-typed-array-names@1.0.0: {}
 

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.6.1'
+const PACKAGE_VERSION = '2.6.2'
 const INTEGRITY_CHECKSUM = '07a8241b182f8a246a7cd39894799a9e'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.6.2'
+const PACKAGE_VERSION = '2.6.1'
 const INTEGRITY_CHECKSUM = '07a8241b182f8a246a7cd39894799a9e'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/redux/createCustomAsyncThunk.ts
+++ b/redux/createCustomAsyncThunk.ts
@@ -29,7 +29,7 @@ const createCustomAsyncThunk = <Returned, ThunkArg = void>(
       try {
         return await payloadCreator(arg, thunkAPI);
       } catch (error: any) {
-        let message = "알 수 없는 오류가 발생했습니다.";
+        let message = "none";
         console.log(error.response.data.message);
         if (
           error.response &&

--- a/redux/createCustomAsyncThunk.ts
+++ b/redux/createCustomAsyncThunk.ts
@@ -1,0 +1,47 @@
+// customCreateAsyncThunk.ts
+import { createAsyncThunk, AsyncThunk } from "@reduxjs/toolkit";
+
+// 서버에서 보내는 에러 메시지 타입 정의
+export interface ServerError {
+  title: string;
+  message: string;
+}
+
+// 커스텀 Thunk API 타입 정의
+interface CustomThunkAPI {
+  rejectValue: { message: string };
+}
+
+// 커스텀 createAsyncThunk 헬퍼 함수
+const createCustomAsyncThunk = <Returned, ThunkArg = void>(
+  typePrefix: string,
+  payloadCreator: (
+    arg: ThunkArg,
+    thunkAPI: {
+      getState: () => any;
+      rejectWithValue: (value: { message: string }) => any;
+    }
+  ) => Promise<Returned>
+): AsyncThunk<Returned, ThunkArg, CustomThunkAPI> => {
+  return createAsyncThunk<Returned, ThunkArg, CustomThunkAPI>(
+    typePrefix,
+    async (arg, thunkAPI) => {
+      try {
+        return await payloadCreator(arg, thunkAPI);
+      } catch (error: any) {
+        let message = "알 수 없는 오류가 발생했습니다.";
+        console.log(error.response.data.message);
+        if (
+          error.response &&
+          error.response.data &&
+          error.response.data.message
+        ) {
+          message = error.response.data.message;
+        }
+        return thunkAPI.rejectWithValue({ message });
+      }
+    }
+  );
+};
+
+export default createCustomAsyncThunk;

--- a/redux/index.ts
+++ b/redux/index.ts
@@ -5,6 +5,7 @@ import feedSlice from "@/domain/feed/slices/feedSlice";
 import memberSlice from "@/domain/member/slices/memberSlice";
 import { loginSlice, signupSlice } from "@/domain/auth/slices";
 import notiSlice from "@/domain/noti/slices/notiSlice";
+import { setAxiosInnerStore } from "@/domain/shared/axios/axiosInstance";
 
 const store = configureStore({
   reducer: {
@@ -33,5 +34,6 @@ const store = configureStore({
   },
 });
 
+setAxiosInnerStore(store);
 export type RootState = ReturnType<typeof store.getState>;
 export default store;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,15 @@ const config: Config = {
         background: "var(--background)",
         foreground: "var(--foreground)",
       },
+      keyframes: {
+        slowPulse: {
+          "0%, 100%": { opacity: "1" },
+          "50%": { opacity: "0.5" },
+        },
+      },
+      animation: {
+        slowPulse: "slowPulse 10s ease-in-out infinite", // 3초로 설정
+      },
       fontFamily: {
         gamja: ["Gamja", "sans-serif"], // 커스텀 폰트 추가
       },


### PR DESCRIPTION
- [x] 비밀번호 정책을 가드를 비밀번호 페이지에서 해야함
- [x] 모든 에러를 메세지를 찍자. 상태코드 X
- [x] 401인 경우에 몇번 에러 다시 보내는지 체크
- [x] 멀티파트 폼 데이터로 전송하는것으로 변경
- [x] 이미지 크기 줄이고 캐릭터 업로드와 생성 등록 로직 분리하기
- [x] next image props src webp에러 해결하기
- [x] 토큰이 있는 경우 401 => 홈 => 재발급처리 필요
- [x] 마이피드 로딩끝났는데 로딩중이라고 보임
- [x] 날짜 일기 작성했는지 표시 하루 뒤로 표시됨
- [x] 달력조회시 timezone 떼고보내기
- [x] 작성완료시 AI코멘트 바로 보이도록 설정
- [x] 업로드 성공시 문구추가
- [x] 한국어로 제목 고정

- [ ] 게시물 없을때 유저한테 깔끔하게 보이게 해주기
- [ ] 더미데이터 삽입

