### PR TITLE
Feature/todak 270/infinite scroll api modify

### DIFF
--- a/app/(main)/home/page.tsx
+++ b/app/(main)/home/page.tsx
@@ -9,7 +9,8 @@ import { useDispatch, useSelector } from "react-redux";
 
 const Page: React.FC = () => {
   const feedList = useSelector((state: RootState) => state.feed.feedList);
-  const feedAfter = useSelector((state: RootState) => state.feed.feedAfter);
+  const feedAfter = feedList.length > 0 ? feedList[feedList.length - 1].publicDiaryId : 0;
+  const feedAfterDate = feedList.length > 0 ? feedList[feedList.length - 1].createdDate : new Date(0).toISOString();
   const [hasMore, setHasMore] = useState(true);
   const dispatch = useDispatch();
 
@@ -23,7 +24,7 @@ const Page: React.FC = () => {
       setHasMore(false);
       return;
     }
-    dispatch<any>(fetchFeedEntries(feedAfter));
+    dispatch<any>(fetchFeedEntries({ after: feedAfter, date: feedAfterDate }));
   };
 
   return (

--- a/app/(main)/my/page.tsx
+++ b/app/(main)/my/page.tsx
@@ -25,16 +25,18 @@ const Page = () => {
   const dispatch = useDispatch();
   const [openModal, setOpenModal] = useState(false);
   const [hasMore, setHasMore] = useState(true);
-  const { myFeedList, myFeedAfter, myFeedEnd, selectedFeed } = useSelector(
+  const { myFeedList, myFeedEnd, selectedFeed } = useSelector(
     (state: RootState) => state.feed
   );
+  const myFeedAfter = myFeedList.length > 0 ? myFeedList[myFeedList.length -1 ].publicDiaryId : 0;
+  const myFeedAfterDate = myFeedList.length > 0 ? myFeedList[myFeedList.length - 1].createdDate : new Date(0).toISOString();
 
   const fetchMoreData = () => {
     if (myFeedEnd) {
       setHasMore(false);
       return;
     }
-    dispatch<any>(fetchMyFeedEntries(myFeedAfter));
+    dispatch<any>(fetchMyFeedEntries({after: myFeedAfter, date: myFeedAfterDate}));
   };
 
   const { nickname, characterImageUrl, email } = useSelector(

--- a/domain/feed/slices/feedExtraReducers.ts
+++ b/domain/feed/slices/feedExtraReducers.ts
@@ -92,9 +92,9 @@ const addUploadFeed = (builder: ActionReducerMapBuilder<FeedState>) => {
 // 나의 공개 일기 불러오기(무한스크롤)  -----------------------------------------------------
 export const fetchMyFeedEntries = createCustomAsyncThunk(
   "Feed/fetchMyFeedEntries",
-  async (params: number) => {
+  async ({after,date} : {after?:number; date?:String}) => {
     const response = await axiosInstance.get(
-      `/diary/my/shared?after=${params}`
+      `/diary/my/shared?after=${after}&date=${date}`
     );
     return response.data;
   }

--- a/domain/feed/slices/feedExtraReducers.ts
+++ b/domain/feed/slices/feedExtraReducers.ts
@@ -12,8 +12,8 @@ import {
 // 일기장 불러오기 (무한 스크롤) -----------------------------------------------------
 export const fetchFeedEntries = createCustomAsyncThunk(
   "feed/fetchFeedEntries",
-  async (params?: number) => {
-    const response = await axiosInstance.get(`/diary/public?after=${params}`);
+  async ({after,date} : {after?: number; date?: String }) => {
+    const response = await axiosInstance.get(`/diary/public?after=${after}&date=${date}`);
     return response.data;
   }
 );


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 무한 스크롤 API 변화에 따라, Front의 무한 스크롤 API 응답 구조를 변경하였습니다.
- 피드(공개 일기) / 나의 피드(나의 공개 일기) 모두 동일하게 해당됩니다.
1. API에서 after 값을(다음 publicDiaryId를 API에게 전달하는 용도) 필드에 담아 주는 것이 아닌, Front 쪽에서 FeedList의 마지막 배열 publicDiaryId를 찾아 API 에게 전달하는 것으로 변경하였습니다.
2. 무한 스크롤 요청시, after 뿐만 아니라, date 값 또한 전달하였습니다.

## 리뷰 받고 싶은 내용

- 혹시 제가 놓친 부분있다면 리뷰 부탁드립니다!

## 테스트 및 결과

## 관련 스크린샷 및 참고자료 (Optional)

close #91 
