### PR TITLE
Feature/todak 277/time utc locale

### DIFF
--- a/app/(main)/diary/page.tsx
+++ b/app/(main)/diary/page.tsx
@@ -6,13 +6,19 @@ import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "@/domain/shared/redux";
 import { AlertButton, ShareDiary } from "@/domain/diary/components";
 import path from "@/domain/shared/routes";
-import MyCalendar from "@/domain/diary/components/Calendar";
 import { setAlert } from "@/domain/noti/slices/notiSlice";
 import { AlertType } from "@/domain/noti/types";
 import checkWriteRole from "@/domain/diary/function/checkRole";
 import { CHARACTER_REQUIRED_ALERT } from "@/domain/shared/constants";
+import dynamic from 'next/dynamic';
+
+const MyCalendar = dynamic(
+    () => import('@/domain/diary/components/Calendar'),
+    { ssr: false }
+);
 
 const Page: React.FC = () => {
+
   const router = useRouter();
   const dispatch = useDispatch();
 

--- a/app/(main)/diary/write/page.tsx
+++ b/app/(main)/diary/write/page.tsx
@@ -67,7 +67,7 @@ const DiaryWritePage: React.FC = () => {
 
     dispatch<any>(
       createDiaryEntry({
-        date: new Date().toDateString(), // 일기 작성 클릭시, 작성 시간 생성
+        date: new Date().toISOString(), // 일기 작성 클릭시, 작성 시간 생성
         emotion: selectedMood,
         content: text,
       })

--- a/app/(main)/diary/write/page.tsx
+++ b/app/(main)/diary/write/page.tsx
@@ -110,7 +110,7 @@ const DiaryWritePage: React.FC = () => {
             <div>
               <p className="text-xs text-gray-500 ml-2">임시저장</p>
               <p className="text-xs text-gray-500 ml-2">
-                {date.toTimeString().slice(0, 8)}
+                {date.toTimeString().slice(0, 5)}
               </p>
             </div>
           </div>

--- a/app/(main)/diary/write/page.tsx
+++ b/app/(main)/diary/write/page.tsx
@@ -67,7 +67,7 @@ const DiaryWritePage: React.FC = () => {
 
     dispatch<any>(
       createDiaryEntry({
-        date: date.toISOString(),
+        date: new Date().toDateString(), // 일기 작성 클릭시, 작성 시간 생성
         emotion: selectedMood,
         content: text,
       })

--- a/app/(main)/my/page.tsx
+++ b/app/(main)/my/page.tsx
@@ -19,6 +19,7 @@ import {
   CarouselAudioEmoji,
   UserAvatarWithLabel,
 } from "@/domain/shared/components";
+import {convertToLocalTimezone} from "@/domain/shared/function/convertToLocalTimeZone";
 
 const Page = () => {
   const router = useRouter();
@@ -91,7 +92,7 @@ const Page = () => {
                     />
                   </div>
                   <p className="w-full mt-1 flex text-xs text-gray-400">
-                    {myFeed.createdDate} 공유
+                    {convertToLocalTimezone(new Date(myFeed.createdDate)).slice(0,10)} 공유
                   </p>
                 </div>
               ))}
@@ -106,7 +107,7 @@ const Page = () => {
             router.push(`${path.READ}/?date=${selectedFeed.diaryCreatedDate}`)
           }
         >
-          ► 원본 일기 ({selectedFeed.diaryCreatedDate}) 보러가기{" "}
+          ► 원본 일기 ({selectedFeed.diaryCreatedDate && `${convertToLocalTimezone(new Date(selectedFeed.diaryCreatedDate)).slice(0,10)}`}) 보러가기{" "}
         </Button>
         <Modal.Body>
           <CarouselAudioEmoji

--- a/domain/diary/components/Calendar.tsx
+++ b/domain/diary/components/Calendar.tsx
@@ -9,6 +9,7 @@ import path from "@/domain/shared/routes";
 import { fetchDiaryStatus } from "../slices/diaryExtraReducers";
 import { DiaryStatusType } from "../types/diaryResponseType";
 import "./Calendar.css";
+import {convertToLocalTimezone} from "@/domain/shared/function/convertToLocalTimeZone";
 
 const MyCalendar: React.FC = () => {
   const date = new Date();
@@ -34,14 +35,16 @@ const MyCalendar: React.FC = () => {
   };
 
   useEffect(() => {
-    const data = `${viewDate.getFullYear()}-${viewDate.getMonth() + 1}`;
-    dispatch<any>(fetchDiaryStatus(data));
+    // const data = `${viewDate.getFullYear()}-${viewDate.getMonth() + 1}`;
+    // const data = viewDate.toISOString();
+    dispatch<any>(fetchDiaryStatus(viewDate.toISOString()));
   }, [viewDate]);
 
-  const isIncludeDiaryStatusList = (date: Date) => {
+  const isIncludeDiaryStatusList = (calendarDate: Date) => {
+    const calendarLocalDate = convertToLocalTimezone(calendarDate);
     return diaryStatusList.some((status: DiaryStatusType) => {
-      const serverDate = new Date(`${status.date}T00:00:00+09:00`);
-      if (date.toLocaleDateString() == serverDate.toLocaleDateString()) {
+      const diaryLocalCreatedDate = convertToLocalTimezone(new Date(status.date));
+      if (calendarLocalDate.slice(0,10) == diaryLocalCreatedDate.slice(0,10)) { // 2024-12-04
         return true;
       }
     });

--- a/domain/diary/components/ShareDiary.tsx
+++ b/domain/diary/components/ShareDiary.tsx
@@ -23,12 +23,9 @@ const ShareDiary: React.FC = () => {
     (state: any) => state.diary.queriedDiary
   );
 
-  const handleDateChage = (date: Date | null) => {
+  const handleDateChange = (date: Date | null) => {
     if (!date) return;
-    const formattedDate = `${date.getFullYear()}-${String(
-      date.getMonth() + 1
-    ).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
-    dispatch<any>(fetchDiaryDetail(formattedDate));
+    dispatch<any>(fetchDiaryDetail(date.toISOString()));
   };
 
   const handleUpload = () => {
@@ -64,7 +61,7 @@ const ShareDiary: React.FC = () => {
   return (
     <>
       <div className="flex justify-between items-center mb-2">
-        <KoDatepicker className="z-50" onChange={handleDateChage} />
+        <KoDatepicker className="z-50" onChange={handleDateChange} />
         <Button
           onClick={handleOpenShareModal}
           className="flex justify-end items-center h-10"

--- a/domain/diary/types/diaryResponseType.ts
+++ b/domain/diary/types/diaryResponseType.ts
@@ -1,4 +1,4 @@
 export type DiaryStatusType = {
   diaryId: number;
-  date: string;
+  date: Date;
 };

--- a/domain/feed/slices/feedExtraReducers.ts
+++ b/domain/feed/slices/feedExtraReducers.ts
@@ -25,7 +25,9 @@ const addFetchFeedEntries = (builder: ActionReducerMapBuilder<FeedState>) => {
   });
   builder.addCase(fetchFeedEntries.fulfilled, (state, action) => {
     state.feedList = [...state.feedList, ...action.payload.diaries];
-    state.feedAfter = action.payload.after;
+    state.feedAfter = state.feedList.length > 0
+        ? state.feedList[state.feedList.length - 1].publicDiaryId
+        : 0;
     state.feedEnd = action.payload.isEnd;
     state.loading = false;
   });
@@ -107,7 +109,9 @@ const addFetchMyFeedEntries = (builder: ActionReducerMapBuilder<FeedState>) => {
   });
   builder.addCase(fetchMyFeedEntries.fulfilled, (state, action) => {
     state.myFeedList = [...state.myFeedList, ...action.payload.sharedDiaries];
-    state.myFeedAfter = action.payload.after;
+    state.myFeedAfter = state.myFeedList.length > 0
+        ? state.myFeedList[state.myFeedList.length - 1].publicDiaryId
+        : 0;;
     state.myFeedEnd = action.payload.isEnd;
     state.loading = false;
   });

--- a/domain/shared/axios/axiosInstance.ts
+++ b/domain/shared/axios/axiosInstance.ts
@@ -8,6 +8,7 @@ const axiosInstance = axios.create({
   withCredentials: true, // 자격증명(리프레시 토큰)을 포함한 쿠키를 서버로 전달
   headers: {
     "Content-Type": "application/json",
+      "Todak-Time-Zone": Intl.DateTimeFormat().resolvedOptions().timeZone,
   },
   timeout: 10000,
 });

--- a/domain/shared/function/convertToLocalTimeZone.ts
+++ b/domain/shared/function/convertToLocalTimeZone.ts
@@ -1,4 +1,5 @@
 export function convertToLocalTimezone(date: Date): string {
+    console.log("convertToLocalTimezone pivot date="+date.toISOString());
     try {
         const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 

--- a/domain/shared/function/convertToLocalTimeZone.ts
+++ b/domain/shared/function/convertToLocalTimeZone.ts
@@ -1,5 +1,4 @@
 export function convertToLocalTimezone(date: Date): string {
-    console.log("convertToLocalTimezone pivot date="+date.toISOString());
     try {
         const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 

--- a/domain/shared/function/convertToLocalTimeZone.ts
+++ b/domain/shared/function/convertToLocalTimeZone.ts
@@ -1,0 +1,41 @@
+export function convertToLocalTimezone(date: Date): string {
+    try {
+        const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+        // 해당 시간대에 맞는 formatter 생성
+        const formatter = new Intl.DateTimeFormat('en-US', {
+            timeZone,
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+            hour12: false,
+            timeZoneName: 'shortOffset',
+            fractionalSecondDigits: 3  // 밀리초 표시를 위해 추가
+        });
+
+        // 시간대 오프셋 추출 (예: "+09:00")
+        const parts = formatter.formatToParts(date);
+        const timeZonePart = parts.find(part => part.type === 'timeZoneName')?.value || '+00:00';
+
+        // 날짜와 시간을 ISO 형식으로 포맷팅
+        const localDate = new Date(date.toLocaleString('en-US', { timeZone }));
+        const milliseconds = date.getMilliseconds().toString().padStart(3, '0');
+
+        const isoDate = localDate.getFullYear().toString().padStart(4, '0') + '-' +
+            String(localDate.getMonth() + 1).padStart(2, '0') + '-' +
+            String(localDate.getDate()).padStart(2, '0') + 'T' +
+            String(localDate.getHours()).padStart(2, '0') + ':' +
+            String(localDate.getMinutes()).padStart(2, '0') + ':' +
+            String(localDate.getSeconds()).padStart(2, '0') + '.' +
+            milliseconds +
+            timeZonePart;
+
+        return isoDate;
+    } catch (error) {
+        console.error('Time conversion error:', error);
+        return date.toISOString();
+    }
+}


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 모든 요청에 대해 ```Todak-Time-Zone``` 헤더에 Time Zone 정보를 담아 요청을 보냅니다.
- 일기 작성을 누른 시점에 Date 객체를 생성하여 시간을 결정합니다.
- 무한 스크롤 API 응답 요청에 after 필드가 없어졌기에, Front 자체적으로 after 값을 찾습니다.
- 연월 일기 현황 및 공유, 피드, 나의 피드 등등의 UI 상으로 나타내는 시간을 모두 Time Zone에 알맞게, 연월일 까지만 나타나도록 수정합니다.

## 리뷰 받고 싶은 내용

- 시간 데이터 중심으로 궁금하신 부분 있다면 알려주세요!

## 테스트 및 결과
- Spring 서버와 연동 및 더미 데이터를 사용하여 테스트 하였습니다.

## 관련 스크린샷 및 참고자료 (Optional)
