### PR TITLE
Feature/todak 292/diary delete UI

### DIFF
--- a/app/(main)/diary/read/page.tsx
+++ b/app/(main)/diary/read/page.tsx
@@ -2,10 +2,10 @@
 
 import React, { Suspense, useEffect } from "react";
 import { Modal } from "flowbite-react";
-import { useSearchParams } from "next/navigation";
+import {useRouter, useSearchParams} from "next/navigation";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "@/domain/shared/redux";
-import { fetchDiaryDetail } from "@/domain/diary/slices/diaryExtraReducers";
+import {deleteDiaryEntry, fetchDiaryDetail} from "@/domain/diary/slices/diaryExtraReducers";
 import { CarouselAudioEmoji } from "@/domain/shared/components";
 
 const DiaryReadPage: React.FC = () => {
@@ -13,9 +13,16 @@ const DiaryReadPage: React.FC = () => {
   const queriedDiary = useSelector(
     (state: RootState) => state.diary.queriedDiary
   );
-  const [showModal, setShowModal] = React.useState(false);
+  const [aiReviewModal, setAiReviewModal] = React.useState(false);
+  const [deleteModal, setDeleteModal] = React.useState(false);
   const searchParams = useSearchParams();
   const date = searchParams.get("date");
+  const router = useRouter();
+  const handleDelete = () => {
+      dispatch<any>(deleteDiaryEntry({ id: queriedDiary.diaryId, date:queriedDiary.date }));
+      setDeleteModal(false);
+      router.push('/diary');
+  };
 
   useEffect(() => {
     if (date) {
@@ -26,31 +33,68 @@ const DiaryReadPage: React.FC = () => {
   return (
     <div className="w-full min-h-screen flex justify-center items-start">
       <div className="w-full max-w-md flex flex-col items-center mt-14">
-        <div className="flex w-full max-w-md relative" onClick={() => {}}>
+        <div className="flex w-full max-w-md relative" onClick={() => {
+        }}>
           <CarouselAudioEmoji
-            webtoonImageUrls={queriedDiary.webtoonImageUrls}
-            bgmUrl={queriedDiary.bgmUrl}
-            diaryId={queriedDiary.diaryId}
+              webtoonImageUrls={queriedDiary.webtoonImageUrls}
+              bgmUrl={queriedDiary.bgmUrl}
+              diaryId={queriedDiary.diaryId}
           />
           <div
-            onClick={() => setShowModal(true)}
-            className="absolute bottom-2 left-2 text-sm font-semibold rounded-full pl-2 pr-2 bg-white opacity-75 border shadow-md"
+              onClick={() => setAiReviewModal(true)}
+              className="absolute bottom-2 left-2 text-sm font-semibold rounded-full pl-2 pr-2 bg-white opacity-75 border shadow-md"
           >
             AI 리뷰
           </div>
+        </div>
+        <div className="w-full flex justify-end px-2">
+          <button
+              type="button"
+              className="focus:outline-none mt-2 text-white bg-red-700 hover:bg-red-800 focus:ring-4 focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2.5 dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-900"
+              onClick={() => setDeleteModal(true)}
+          >
+            삭제
+          </button>
         </div>
         <div className="w-full max-w-md">
           <p className="text-md h-full p-2 rounded-none overflow-y-auto whitespace-pre-wrap">
             {queriedDiary.content}
           </p>
         </div>
-        <Modal show={showModal} onClose={() => setShowModal(false)}>
+        <Modal show={aiReviewModal} onClose={() => setAiReviewModal(false)}>
           <Modal.Header className="font-gamja">토닥토닥 AI</Modal.Header>
           <Modal.Body>
             <div className="space-y-6">
               <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
                 {queriedDiary.aiComment}
               </p>
+            </div>
+          </Modal.Body>
+        </Modal>
+        <Modal show={deleteModal} onClose={() => setDeleteModal(false)}>
+          <Modal.Header className="font-gamja">정말로 삭제하시겠습니까?</Modal.Header>
+          <Modal.Body>
+            <div className="space-y-6 flex justify-center px-2 py-1">
+              <div className="w-full max-w-md flex flex-col justify-center items-center" >
+                <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
+                  공개한 일기도 함께 삭제됩니다.
+                </p>
+                <div className="w-full max-w-xs mx-auto flex flex-row justify-center gap-5 items-center mt-5">
+                  <button
+                      type="button"
+                      className="flex-1 focus:outline-none text-white bg-red-700 hover:bg-red-800 focus:ring-4 focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2.5 dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-900"
+                      onClick={() => handleDelete()}
+                  >
+                    예
+                  </button>
+                  <button type="button"
+                          className="flex-1 text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800"
+                          onClick = {() => setDeleteModal(false)}
+                  >
+                    아니오
+                  </button>
+                </div>
+              </div>
             </div>
           </Modal.Body>
         </Modal>
@@ -61,9 +105,9 @@ const DiaryReadPage: React.FC = () => {
 
 const Page: React.FC = () => {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <DiaryReadPage />
-    </Suspense>
+      <Suspense fallback={<div>Loading...</div>}>
+        <DiaryReadPage/>
+      </Suspense>
   );
 };
 

--- a/app/(main)/diary/read/page.tsx
+++ b/app/(main)/diary/read/page.tsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "@/domain/shared/redux";
 import {deleteDiaryEntry, fetchDiaryDetail} from "@/domain/diary/slices/diaryExtraReducers";
 import { CarouselAudioEmoji } from "@/domain/shared/components";
+import path from "@/domain/shared/routes";
 
 const DiaryReadPage: React.FC = () => {
   const dispatch = useDispatch();
@@ -21,7 +22,7 @@ const DiaryReadPage: React.FC = () => {
   const handleDelete = () => {
       dispatch<any>(deleteDiaryEntry({ id: queriedDiary.diaryId, date:queriedDiary.date }));
       setDeleteModal(false);
-      router.push('/diary');
+      router.push(path.DIARY);
   };
 
   useEffect(() => {

--- a/app/(main)/my/page.tsx
+++ b/app/(main)/my/page.tsx
@@ -9,6 +9,7 @@ import { useDispatch, useSelector } from "react-redux";
 import InfiniteScroll from "react-infinite-scroll-component";
 import { Button, Modal } from "flowbite-react";
 import {
+  deleteMyFeed,
   fetchMyFeedDetail,
   fetchMyFeedEntries,
 } from "@/domain/feed/slices/feedExtraReducers";
@@ -26,6 +27,7 @@ const Page = () => {
   const dispatch = useDispatch();
   const [openModal, setOpenModal] = useState(false);
   const [hasMore, setHasMore] = useState(true);
+  const[deleteModal,setDeleteModal] = useState(false);
   const { myFeedList, myFeedEnd, selectedFeed } = useSelector(
     (state: RootState) => state.feed
   );
@@ -39,6 +41,14 @@ const Page = () => {
     }
     dispatch<any>(fetchMyFeedEntries({after: myFeedAfter, date: myFeedAfterDate}));
   };
+
+  const handleDelete = (publicDiaryId: number) => {
+    dispatch<any>(deleteMyFeed(publicDiaryId));
+    setDeleteModal(false);
+    setOpenModal(false);
+    window.location.reload();
+    // dispatch<any>(fetchMyFeedEntries({}));
+  }
 
   const { nickname, characterImageUrl, email } = useSelector(
     (state: RootState) => state.member.profile
@@ -111,12 +121,48 @@ const Page = () => {
         </Button>
         <Modal.Body>
           <CarouselAudioEmoji
-            webtoonImageUrls={selectedFeed.webtoonImageUrls}
-            bgmUrl={selectedFeed.bgmUrl}
-            reactionCount={selectedFeed.reactionCount}
-            myReaction={selectedFeed.myReaction}
-            diaryId={selectedFeed.publicDiaryId}
+              webtoonImageUrls={selectedFeed.webtoonImageUrls}
+              bgmUrl={selectedFeed.bgmUrl}
+              reactionCount={selectedFeed.reactionCount}
+              myReaction={selectedFeed.myReaction}
+              diaryId={selectedFeed.publicDiaryId}
           />
+          <div className="w-full flex justify-end px-2">
+            <button
+                type="button"
+                className="focus:outline-none mt-2 text-white bg-red-700 hover:bg-red-800 focus:ring-4 focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2.5 dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-900"
+                onClick={() => setDeleteModal(true)}
+            >
+              삭제
+            </button>
+          </div>
+          <Modal show={deleteModal} onClose={() => setDeleteModal(false)}>
+            <Modal.Header className="font-gamja">정말로 삭제하시겠습니까?</Modal.Header>
+            <Modal.Body>
+              <div className="space-y-6 flex justify-center px-2 py-1">
+                <div className="w-full max-w-md flex flex-col justify-center items-center">
+                  <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
+                    공개 일기를 삭제합니다.
+                  </p>
+                  <div className="w-full max-w-xs mx-auto flex flex-row justify-center gap-5 items-center mt-5">
+                    <button
+                        type="button"
+                        className="flex-1 focus:outline-none text-white bg-red-700 hover:bg-red-800 focus:ring-4 focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2.5 dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-900"
+                        onClick={() => handleDelete(selectedFeed.publicDiaryId)}
+                    >
+                      예
+                    </button>
+                    <button type="button"
+                            className="flex-1 text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800"
+                            onClick={() => setDeleteModal(false)}
+                    >
+                      아니오
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </Modal.Body>
+          </Modal>
           <p className="p-1">{selectedFeed.publicContent}</p>
         </Modal.Body>
       </Modal>

--- a/domain/diary/dto/request/deleteDiaryDto.ts
+++ b/domain/diary/dto/request/deleteDiaryDto.ts
@@ -3,39 +3,32 @@ import { isValidDate } from "@/domain/shared/function";
 // 일기 삭제 타입 정의 -----------------------------------------------------
 export type DeleteDiaryEntryType = {
   date: string;
-  emotion: string;
-  content: string;
+  id: number;
 };
 
 // 일기 삭제 요청 DTO 클래스 -----------------------------------------------------
 export class DeleteDiaryEntryRequestDto implements DeleteDiaryEntryType {
   public date: string;
-  public emotion: string;
-  public content: string;
+  public id: number;
 
   // 네임드 파라미터 방식의 생성자
-  constructor({ date, emotion, content }: DeleteDiaryEntryType) {
+  constructor({ date, id }: DeleteDiaryEntryType) {
     if (!isValidDate(date)) {
       throw new Error("유효하지 않은 날짜 형식입니다.");
     }
-    if (!emotion) {
-      throw new Error("감정표현 내용이 필요합니다.");
-    }
-    if (!content) {
-      throw new Error("일기 내용이 필요합니다.");
+    if (!id) {
+      throw new Error("일기 ID가 필요합니다.")
     }
 
     this.date = date;
-    this.emotion = emotion.trim();
-    this.content = content.trim();
+    this.id = id;
   }
 
   // 객체 형태로 반환
   toObject(): DeleteDiaryEntryType {
     return {
       date: this.date,
-      emotion: this.emotion,
-      content: this.content,
+      id: this.id
     };
   }
 }

--- a/domain/diary/slices/diaryExtraReducers.ts
+++ b/domain/diary/slices/diaryExtraReducers.ts
@@ -108,7 +108,7 @@ export const deleteDiaryEntry = createCustomAsyncThunk(
   "diary/deleteDiaryEntry",
   async (data: DeleteDiaryEntryType) => {
     const deleteDiaryEntryDto = new DeleteDiaryEntryRequestDto(data);
-    const response = await axiosInstance.delete("/diary/my/1", {
+    const response = await axiosInstance.delete(`/diary/my/${deleteDiaryEntryDto.id}`, {
       data: deleteDiaryEntryDto.toObject(),
     });
     return response.data;

--- a/domain/feed/slices/feedExtraReducers.ts
+++ b/domain/feed/slices/feedExtraReducers.ts
@@ -94,7 +94,7 @@ const addUploadFeed = (builder: ActionReducerMapBuilder<FeedState>) => {
 // 나의 공개 일기 불러오기(무한스크롤)  -----------------------------------------------------
 export const fetchMyFeedEntries = createCustomAsyncThunk(
   "Feed/fetchMyFeedEntries",
-  async ({after,date} : {after?:number; date?:String}) => {
+  async ({after = 0,date = ""} : {after?:number; date?:String}) => {
     const response = await axiosInstance.get(
       `/diary/my/shared?after=${after}&date=${date}`
     );
@@ -147,6 +147,32 @@ const addFetchMyFeedDetail = (builder: ActionReducerMapBuilder<FeedState>) => {
   });
 };
 
+// 나의 공개 일기 삭제---------------------------------------------
+
+export const deleteMyFeed = createCustomAsyncThunk(
+    "Feed/deleteMyFeed",
+    async (id: number) => {
+      const response = await axiosInstance.delete(
+          `/diary/my/shared/${id}`
+      );
+      return;
+    }
+);
+
+const addDeleteMyFeed = (builder: ActionReducerMapBuilder<FeedState>) => {
+  builder.addCase(deleteMyFeed.pending, (state) => {
+    state.loading = true;
+    state.error = null;
+  });
+  builder.addCase(deleteMyFeed.fulfilled, (state, action) => {
+    state.loading = false;
+  });
+  builder.addCase(deleteMyFeed.rejected, (state, action) => {
+    state.loading = false;
+    state.error = action.payload?.message ?? null;
+  });
+}
+
 // extra reducers 추가 -----------------------------------------------------
 export const addFeedExtraReducers = (
   builder: ActionReducerMapBuilder<FeedState>
@@ -156,4 +182,5 @@ export const addFeedExtraReducers = (
   addUploadFeed(builder);
   addFetchMyFeedEntries(builder);
   addFetchMyFeedDetail(builder);
+  addDeleteMyFeed(builder)
 };


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?
- [ ] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 일기 상세 보기에서 [삭제] 버튼 및 기능을 구현하였습니다.
![image](https://github.com/user-attachments/assets/7f3dcf4f-6b5a-4915-bfb6-e0928a60394b)


- 나의 공개 일기 상세 보기에서 [삭제] 버튼 및 기능을 구현하였습니다.
![image](https://github.com/user-attachments/assets/93cb0d15-8a2a-49c5-9c10-a530304ace90)
![image](https://github.com/user-attachments/assets/2ea8f1f6-d78f-4e7b-bd73-b045e5633631)



## 리뷰 받고 싶은 내용

- 궁금하신 부분 있으시다면 알려주세요!

## 테스트 및 결과
- Front에서 캐싱을 해서인지, 공개 일기 삭제/생성 이후 [내 정보] 로 가서 나의 공개 일기 조회시 바로 데이터가 보이지 않습니다.
새로 고침을 해야 보이거나, 삭제한 것이 사라지게 되는데 이 문제는 추후에 수정이 필요할 것 같습니다.

## 관련 스크린샷 및 참고자료 (Optional)

close #97 