### PR TITLE
feat: 일기 작성 BGM 장르 선택 UI 추가 TODAK-300

### DIFF
--- a/app/(main)/diary/write/page.tsx
+++ b/app/(main)/diary/write/page.tsx
@@ -19,9 +19,11 @@ import path from "@/domain/shared/routes";
 import { MoodSelector } from "@/domain/diary/components/MoodSelector";
 import { DiaryTextArea } from "@/domain/diary/components/DiaryTextArea";
 import { AlertType } from "@/domain/noti/types";
+import { GenreSelector } from "@/domain/diary/components/GenreSelector";
 
 const DiaryWritePage: React.FC = () => {
   const [selectedMood, setSelectedMood] = useState<string | null>(null);
+  const [selectedBgmGenre, setSelectedBgmGenre] = useState<string | null>(null);
   const [text, handleChangeText, removeTextLocalStorage] =
     useSaveTextLocalStorage({
       key: "diaryText",
@@ -32,11 +34,15 @@ const DiaryWritePage: React.FC = () => {
   const date = new Date();
 
   const { aiComment, commentView, isDiarySaved } = useSelector(
-    (state: RootState) => state.diary
+    (state: RootState) => state.diary,
   );
 
   const handleMoodSelect = (mood: string) => {
     setSelectedMood(mood === selectedMood ? null : mood);
+  };
+
+  const handleGenreSelect = (bgmGenre: string) => {
+    setSelectedBgmGenre(bgmGenre === selectedBgmGenre ? null : bgmGenre);
   };
 
   const handleSaveDiary = () => {
@@ -54,13 +60,24 @@ const DiaryWritePage: React.FC = () => {
       return;
     }
 
-    if (!selectedMood) {
+    if (!selectedBgmGenre || !selectedMood) {
       dispatch(
         setAlert({
           title: "알림",
-          message: "기분을 선택해주세요",
+          message: "기분과 BGM 장르를 선택해주세요.",
           color: "warning",
-        })
+        }),
+      );
+      return;
+    }
+
+    if (text.length < 100) {
+      dispatch(
+        setAlert({
+          title: "알림",
+          message: "일기는 100자 이상 작성해 주세요.",
+          color: "warning",
+        }),
       );
       return;
     }
@@ -70,7 +87,8 @@ const DiaryWritePage: React.FC = () => {
         date: new Date().toISOString(), // 일기 작성 클릭시, 작성 시간 생성
         emotion: selectedMood,
         content: text,
-      })
+        bgmGenre: selectedBgmGenre,
+      }),
     );
   };
 
@@ -83,7 +101,7 @@ const DiaryWritePage: React.FC = () => {
         title: "알림",
         message: "일기가 저장되었습니다.",
         color: "success",
-      })
+      }),
     );
   };
 
@@ -126,6 +144,10 @@ const DiaryWritePage: React.FC = () => {
         <MoodSelector
           selectedMood={selectedMood}
           onMoodSelect={handleMoodSelect}
+        />
+        <GenreSelector
+          selectedGenre={selectedBgmGenre}
+          onGenreSelect={handleGenreSelect}
         />
         <DiaryTextArea text={text} onChange={handleChangeText} />
       </div>

--- a/domain/diary/components/DiaryTextArea.tsx
+++ b/domain/diary/components/DiaryTextArea.tsx
@@ -13,7 +13,7 @@ export const DiaryTextArea = ({ text, onChange }: DiaryTextAreaProps) => {
         maxLength={3000}
         value={text}
         onChange={onChange}
-        placeholder="오늘의 이야기를 들려주세요..."
+        placeholder="오늘의 이야기를 들려주세요! (100자 이상)"
       />
       <div className="absolute bottom-4 right-4 text-sm text-gray-500">
         {text.length} / 3000

--- a/domain/diary/components/GenreSelector.tsx
+++ b/domain/diary/components/GenreSelector.tsx
@@ -1,0 +1,33 @@
+import { Label } from "flowbite-react";
+import { BGM_GENRE_COLORS, BGM_GENRES } from "../constants";
+
+interface GenreSelectorProps {
+  selectedGenre: string | null;
+  onGenreSelect: (genre: string) => void;
+}
+
+export const GenreSelector = ({
+  selectedGenre,
+  onGenreSelect,
+}: GenreSelectorProps) => {
+  return (
+    <Label className="mb-4">
+      <p className="mb-2 mt-4">BGM 장르를 선택해주세요.</p>
+      <div>
+        {BGM_GENRES.map((genre) => (
+          <span
+            key={genre}
+            className={`text-xs font-medium me-2 px-3 py-1 rounded-full cursor-pointer ${
+              selectedGenre === genre
+                ? BGM_GENRE_COLORS[genre]
+                : "bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-300"
+            }`}
+            onClick={() => onGenreSelect(genre)}
+          >
+            {genre}
+          </span>
+        ))}
+      </div>
+    </Label>
+  );
+};

--- a/domain/diary/constants/genre.ts
+++ b/domain/diary/constants/genre.ts
@@ -1,0 +1,18 @@
+export const BGM_GENRES = [
+  "팝",
+  "락",
+  "어쿠스틱",
+  "재즈",
+  "클래식",
+  "EDM",
+] as const;
+
+export const BGM_GENRE_COLORS = {
+  팝: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300",
+  락: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300",
+  어쿠스틱:
+    " bg-yellow-100 text-yellow-800 dark:bg-yellow-700 dark:text-yellow-300",
+  재즈: "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-300",
+  클래식: "bg-gray-500 text-gray-100 dark:bg-gray-900 dark:text-gray-300",
+  EDM: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-300",
+} as const;

--- a/domain/diary/constants/index.ts
+++ b/domain/diary/constants/index.ts
@@ -1,3 +1,5 @@
-import { MOODS, MOOD_COLORS } from "./mood";
+import { MOOD_COLORS, MOODS } from "./mood";
+import { BGM_GENRE_COLORS, BGM_GENRES } from "./genre";
 
 export { MOODS, MOOD_COLORS };
+export { BGM_GENRES, BGM_GENRE_COLORS };

--- a/domain/diary/dto/request/createDiaryDto.ts
+++ b/domain/diary/dto/request/createDiaryDto.ts
@@ -1,10 +1,11 @@
-import { isValidDate } from "@/domain/shared/function";
+import { isValidDate } from "@/domain/shared/function"; // 일기 작성 타입 정의 -----------------------------------------------------
 
 // 일기 작성 타입 정의 -----------------------------------------------------
 export type CreateDiaryEntryType = {
   date: string;
   emotion: string;
   content: string;
+  bgmGenre: string;
 };
 
 // 일기 작성 요청 DTO 클래스 -----------------------------------------------------
@@ -12,9 +13,10 @@ export class CreateDiaryEntryRequestDto implements CreateDiaryEntryType {
   public date: string;
   public emotion: string;
   public content: string;
+  public bgmGenre: string;
 
   // 네임드 파라미터 방식의 생성자
-  constructor({ date, emotion, content }: CreateDiaryEntryType) {
+  constructor({ date, emotion, content, bgmGenre }: CreateDiaryEntryType) {
     if (!isValidDate(date)) {
       throw new Error("날짜 포맷이 올바르지 않습니다.");
     }
@@ -24,10 +26,14 @@ export class CreateDiaryEntryRequestDto implements CreateDiaryEntryType {
     if (!content) {
       throw new Error("내용을 입력해주세요.");
     }
+    if (!bgmGenre) {
+      throw new Error("음악 장르를 선택해주세요.");
+    }
 
     this.date = date;
     this.emotion = this.mapEmotionToEnglish(emotion.trim());
     this.content = content.trim();
+    this.bgmGenre = this.mapGenreToEnglish(bgmGenre.trim());
   }
 
   // 한국어 기분을 영어로 변환하는 메서드
@@ -42,12 +48,26 @@ export class CreateDiaryEntryRequestDto implements CreateDiaryEntryType {
     return emotionMap[emotion] || emotion; // 매핑되지 않은 경우 원래 값 반환
   }
 
+  // 한국어 장르를 영어로 변환하는 메서드
+  private mapGenreToEnglish(genre: string): string {
+    const genreMap: { [key: string]: string } = {
+      팝: "pop",
+      락: "rock",
+      어쿠스틱: "acoustic",
+      재즈: "jazz",
+      클래식: "classical",
+      EDM: "edm",
+    };
+    return genreMap[genre] || genre; // 매핑되지 않은 경우 원래 값 반환
+  }
+
   // 객체 형태로 반환
   toObject(): CreateDiaryEntryType {
     return {
       date: this.date,
       emotion: this.emotion,
       content: this.content,
+      bgmGenre: this.bgmGenre,
     };
   }
 }


### PR DESCRIPTION
<details>
<summary> PR 체크리스트</summary>
  
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. #1 [feat] 소셜 로그인 구현
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
- [x] 🙇‍♂️ 리뷰어를 지정했나요? (페어가 존재할 시)
</details>

## 변경사항

- 일기 작성시 음악 장르를 선택합니다.
![image](https://github.com/user-attachments/assets/4eacb4a3-0ae9-4cdc-982f-bdf4adeb46f7)

![image](https://github.com/user-attachments/assets/39b0829a-8c02-4600-8a03-3748cadbddc5)


## 리뷰 받고 싶은 내용

- 궁금하신 부분 있으시다면 알려주세요!

## 테스트 및 결과
- 로컬 서버를 띄워 간단히 진행해 보았습니다!

## 관련 스크린샷 및 참고자료 (Optional)

close #100